### PR TITLE
Hypercoil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `hypercoil`: all-in-one binary integrating all coil commands (#25)
+
 ## [0.2] - 2018-10-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This repository contains these programs:
 * `coild`: A background service to manage IP address.
 * `coil-controller`: watches kubernetes resources for coil.
 * `coil-installer`: installs `coil` and CNI configuration file.
+* `hypercoil`: all-in-one binary just like `hyperkube`.
 
 `coil` should be installed in `/opt/cni/bin` directory.
 

--- a/cmd/coil-controller/cmd/root.go
+++ b/cmd/coil-controller/cmd/root.go
@@ -1,0 +1,101 @@
+// Copyright © 2018 Cybozu
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/cybozu-go/coil"
+	"github.com/cybozu-go/coil/controller"
+	"github.com/cybozu-go/coil/model"
+	"github.com/cybozu-go/etcdutil"
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var etcdConfig *etcdutil.Config
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "coil-controller",
+	Short: "A kubernetes controller for coil",
+	Long: `coil-controller is a Kubernetes controller to maintain coil resources.
+
+It should be deployed as a Deployment pod in Kunernetes.
+`,
+
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		err := well.LogConfig{}.Apply()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+	},
+
+	Run: func(cmd *cobra.Command, args []string) {
+		err := coil.ResolveEtcdEndpoints(etcdConfig)
+		if err != nil {
+			log.ErrorExit(err)
+		}
+
+		etcd, err := etcdutil.NewClient(etcdConfig)
+		if err != nil {
+			log.ErrorExit(err)
+		}
+		defer etcd.Close()
+
+		db := model.NewEtcdModel(etcd)
+		cntl, err := controller.NewController(db)
+		if err != nil {
+			log.ErrorExit(err)
+		}
+
+		well.Go(func(ctx context.Context) error {
+			rev, err := cntl.Sync(ctx)
+			if err != nil {
+				return err
+			}
+
+			return cntl.Watch(ctx, rev)
+		})
+
+		err = well.Wait()
+		if err != nil && !well.IsSignaled(err) {
+			log.ErrorExit(err)
+		}
+	},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	etcdConfig = coil.NewEtcdConfig()
+	etcdConfig.AddPFlags(rootCmd.PersistentFlags())
+}

--- a/cmd/coil-controller/main.go
+++ b/cmd/coil-controller/main.go
@@ -1,54 +1,27 @@
+// Copyright © 2018 Cybozu
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package main
 
-import (
-	"context"
-	"flag"
-
-	"github.com/cybozu-go/coil"
-	"github.com/cybozu-go/coil/controller"
-	"github.com/cybozu-go/coil/model"
-	"github.com/cybozu-go/etcdutil"
-	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/well"
-)
+import "github.com/cybozu-go/coil/cmd/coil-controller/cmd"
 
 func main() {
-	cfg := coil.NewEtcdConfig()
-	cfg.AddFlags(flag.CommandLine)
-	flag.Parse()
-	err := well.LogConfig{}.Apply()
-	if err != nil {
-		log.ErrorExit(err)
-	}
-
-	err = coil.ResolveEtcdEndpoints(cfg)
-	if err != nil {
-		log.ErrorExit(err)
-	}
-
-	etcd, err := etcdutil.NewClient(cfg)
-	if err != nil {
-		log.ErrorExit(err)
-	}
-	defer etcd.Close()
-
-	db := model.NewEtcdModel(etcd)
-	cntl, err := controller.NewController(db)
-	if err != nil {
-		log.ErrorExit(err)
-	}
-
-	well.Go(func(ctx context.Context) error {
-		rev, err := cntl.Sync(ctx)
-		if err != nil {
-			return err
-		}
-
-		return cntl.Watch(ctx, rev)
-	})
-
-	err = well.Wait()
-	if err != nil && !well.IsSignaled(err) {
-		log.ErrorExit(err)
-	}
+	cmd.Execute()
 }

--- a/cmd/coild/cmd/root.go
+++ b/cmd/coild/cmd/root.go
@@ -1,0 +1,132 @@
+// Copyright © 2018 Cybozu
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/cybozu-go/coil"
+	"github.com/cybozu-go/coil/coild"
+	"github.com/cybozu-go/coil/model"
+	"github.com/cybozu-go/etcdutil"
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultListenHTTP = "127.0.0.1:9383"
+	defaultTableID    = 119
+	defaultProtocolID = 30
+)
+
+var config struct {
+	endpoint   string
+	tableID    int
+	protocolID int
+}
+
+var etcdConfig *etcdutil.Config
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "coild",
+	Short: "Backend service to allocate IP address",
+	Long: `coild is a backend service to allocate IP address.
+
+It normally run as a DaemonSet container in Kubernetes.
+Following environment variables need to be set:
+
+    COIL_NODE_NAME:  The node name where the container is running.
+    COIL_NODE_IP:    A routable IP address to the node.
+`,
+
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		err := well.LogConfig{}.Apply()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+	},
+
+	Run: func(cmd *cobra.Command, args []string) {
+		err := coil.ResolveEtcdEndpoints(etcdConfig)
+		if err != nil {
+			log.ErrorExit(err)
+		}
+
+		etcd, err := etcdutil.NewClient(etcdConfig)
+		if err != nil {
+			log.ErrorExit(err)
+		}
+		defer etcd.Close()
+
+		db := model.NewEtcdModel(etcd)
+		server := coild.NewServer(db, config.tableID, config.protocolID)
+
+		well.Go(func(ctx context.Context) error {
+			return subMain(ctx, server)
+		})
+		err = well.Wait()
+		if err != nil && !well.IsSignaled(err) {
+			log.ErrorExit(err)
+		}
+	},
+}
+
+func subMain(ctx context.Context, server *coild.Server) error {
+	err := server.Init(ctx)
+	if err != nil {
+		return nil
+	}
+
+	webServer := &well.HTTPServer{
+		Server: &http.Server{
+			Addr:    config.endpoint,
+			Handler: server,
+		},
+		ShutdownTimeout: 3 * time.Minute,
+	}
+	webServer.ListenAndServe()
+	return nil
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	etcdConfig = coil.NewEtcdConfig()
+	etcdConfig.AddPFlags(rootCmd.PersistentFlags())
+
+	fs := rootCmd.Flags()
+	fs.StringVar(&config.endpoint, "http", defaultListenHTTP, "REST API endpoint")
+	fs.IntVar(&config.tableID, "table-id", defaultTableID, "Routing table ID to export routes")
+	fs.IntVar(&config.protocolID, "protocol-id", defaultProtocolID, "Route author ID")
+}

--- a/cmd/coild/config.go
+++ b/cmd/coild/config.go
@@ -1,7 +1,0 @@
-package main
-
-const (
-	defaultListenHTTP = "127.0.0.1:9383"
-	defaultTableID    = 119
-	defaultProtocolID = 30
-)

--- a/cmd/hypercoil/main.go
+++ b/cmd/hypercoil/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/version"
+	controller "github.com/cybozu-go/coil/cmd/coil-controller/cmd"
+	installer "github.com/cybozu-go/coil/cmd/coil-installer/cmd"
+	coilctl "github.com/cybozu-go/coil/cmd/coilctl/cmd"
+	coild "github.com/cybozu-go/coil/cmd/coild/cmd"
+	"github.com/cybozu-go/coil/cni"
+)
+
+func usage() {
+	io.WriteString(os.Stderr, `Usage: hypercoil COMMAND [ARGS ...]
+
+COMMAND:
+    - coil               CNI plugin.
+    - coild              DaemonSet service.
+    - coil-controller    Kubernetes controller for coil.
+    - coilctl            Command-line utility.
+    - coil-installer     Installs coil.
+`)
+}
+
+func main() {
+	name := filepath.Base(os.Args[0])
+	if name == "hypercoil" {
+		if len(os.Args) == 1 {
+			usage()
+			os.Exit(1)
+		}
+		name = os.Args[1]
+		os.Args = os.Args[1:]
+	}
+
+	switch name {
+	case "coil":
+		skel.PluginMain(cni.Add, cni.Del, version.All)
+	case "coild":
+		coild.Execute()
+	case "coil-controller":
+		controller.Execute()
+	case "coilctl":
+		coilctl.Execute()
+	case "coil-installer":
+		installer.Execute()
+	default:
+		usage()
+		os.Exit(1)
+	}
+}

--- a/mtest/Makefile
+++ b/mtest/Makefile
@@ -53,13 +53,18 @@ all: test
 $(OUTPUT)/coil.img:
 	rm -rf tmpbin
 	mkdir tmpbin
-	cd ..; GOBIN=$(shell pwd)/tmpbin CGO_ENABLED=0 go install -mod=vendor ./...
+	cd ..; GOBIN=$(shell pwd)/tmpbin CGO_ENABLED=0 go install -mod=vendor ./cmd/hypercoil
+	ln -s hypercoil tmpbin/coil
+	ln -s hypercoil tmpbin/coild
+	ln -s hypercoil tmpbin/coil-controller
+	ln -s hypercoil tmpbin/coilctl
+	ln -s hypercoil tmpbin/coil-installer
 	sudo podman build --rm=false -f Dockerfile -t quay.io/cybozu/coil:dev tmpbin
 	mkdir -p $(OUTPUT)
 	sudo podman save -o $@ quay.io/cybozu/coil:dev
 
 $(OUTPUT)/coilctl: $(OUTPUT)/coil.img
-	cp tmpbin/coilctl $(OUTPUT)
+	cp tmpbin/coilctl $@
 
 $(MANAGEMENT_ETCD_ARCHIVE):
 	curl -sSLf -o $@ https://github.com/coreos/etcd/releases/download/v$(MANAGEMENT_ETCD_VERSION)/etcd-v$(MANAGEMENT_ETCD_VERSION)-linux-amd64.tar.gz

--- a/mtest/deploy.yml
+++ b/mtest/deploy.yml
@@ -90,10 +90,10 @@ spec:
           image: quay.io/cybozu/coil:dev
           command:
             - /coild
-            - "-etcd-endpoints=@cke-etcd"
-            - "-etcd-tls-ca=/coil-secrets/cacert"
-            - "-etcd-tls-cert=/coil-secrets/cert"
-            - "-etcd-tls-key=/coil-secrets/key"
+            - "--etcd-endpoints=@cke-etcd"
+            - "--etcd-tls-ca=/coil-secrets/cacert"
+            - "--etcd-tls-cert=/coil-secrets/cert"
+            - "--etcd-tls-key=/coil-secrets/key"
           env:
             - name: COIL_NODE_NAME
               valueFrom:

--- a/mtest/deploy.yml
+++ b/mtest/deploy.yml
@@ -206,10 +206,11 @@ spec:
           image: quay.io/cybozu/coil:dev
           command:
             - /coil-controller
-            - "-etcd-endpoints=@cke-etcd"
-            - "-etcd-tls-ca=/coil-secrets/cacert"
-            - "-etcd-tls-cert=/coil-secrets/cert"
-            - "-etcd-tls-key=/coil-secrets/key"
+            - "--etcd-endpoints=@cke-etcd"
+            - "--etcd-tls-ca=/coil-secrets/cacert"
+            - "--etcd-tls-cert=/coil-secrets/cert"
+            - "--etcd-tls-key=/coil-secrets/key"
+          # for "kubectl exec POD coilctl"
           env:
             - name: COILCTL_ENDPOINTS
               value: "@cke-etcd"


### PR DESCRIPTION
Just like `hyperkube`, `hypercoil` is a single executable that integrates all coil commands.

`hypercoil` can invoke each coil command in two ways:

1. Invoke `hypercoil` executable with an alias using symlink.
2. Invoke `hypercoil COMMAND`.

For instance, `coilctl` can be invoked by:

    $ ln -s hypercoil coilctl
    $ ./coilctl

or:

    $ ./hypercoil coilctl

The resulting container image size decreases to ~36MB without stripping.