### PR TITLE
Delete host-side veth if exists in CNI ADD.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,15 @@ jobs:
           runtime: docker
           suite: ./functions
           kubernetes-version: "1.15"
+  mtest-failures:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - checkout
+      - run-mtest:
+          runtime: remote
+          suite: ./failures
+          kubernetes-version: "1.15"
   mtest-k8s-v1_14:
     docker:
       - image: google/cloud-sdk
@@ -132,6 +141,7 @@ workflows:
             - build
       - mtest-containerd
       - mtest-docker
+      - mtest-failures
       - mtest-k8s-v1_14
       - mtest-k8s-v1_13
   release:

--- a/cni/add.go
+++ b/cni/add.go
@@ -102,6 +102,13 @@ func setupVethPair(contVethName, namespace, podname string, mtu int, hostNS ns.N
 		return net.Interface{}, net.Interface{}, fmt.Errorf("failed to lookup %q: %v", hostVethName, err)
 	}
 
+	err = hostNS.Do(func(_ ns.NetNS) error {
+		return deleteVethIfExists(hostVethName)
+	})
+	if err != nil {
+		return net.Interface{}, net.Interface{}, fmt.Errorf("failed to delete host veth %q: %v", hostVethName, err)
+	}
+
 	if err = netlink.LinkSetNsFd(hostVeth, int(hostNS.Fd())); err != nil {
 		return net.Interface{}, net.Interface{}, fmt.Errorf("failed to move veth to host netns: %v", err)
 	}
@@ -143,8 +150,9 @@ func generateHostVethName(prefix, namespace, podname string) string {
 func makeVeth(name, namespace, podname string, mtu int) (peerName string, veth netlink.Link, err error) {
 	peerName = generateHostVethName("veth", namespace, podname)
 
-	err = deletePeerIfExists(peerName)
+	err = deleteVethIfExists(peerName)
 	if err != nil {
+		err = fmt.Errorf("failed to delete peer veth %q: %v", peerName, err)
 		return
 	}
 
@@ -179,14 +187,16 @@ func makeVethPair(name, peer string, mtu int) (netlink.Link, error) {
 	return veth2, nil
 }
 
-func deletePeerIfExists(name string) error {
-	if oldHostVeth, err := netlink.LinkByName(name); err == nil {
-		err := netlink.LinkDel(oldHostVeth)
-		if err != nil {
-			return err
-		}
+func deleteVethIfExists(name string) error {
+	oldVeth, err := netlink.LinkByName(name)
+	switch err.(type) {
+	case nil:
+		return netlink.LinkDel(oldVeth)
+	case netlink.LinkNotFoundError:
+		return nil
+	default:
+		return err
 	}
-	return nil
 }
 
 // addRouteInHost does:

--- a/cni/add.go
+++ b/cni/add.go
@@ -96,6 +96,9 @@ func setupVethPair(contVethName, namespace, podname string, mtu int, hostNS ns.N
 	if err = netlink.LinkSetUp(contVeth); err != nil {
 		return net.Interface{}, net.Interface{}, fmt.Errorf("failed to set %q up: %v", contVethName, err)
 	}
+	if injectFailures {
+		panicForFirstRun("AfterMakingVethPairInContainerNS")
+	}
 
 	hostVeth, err := netlink.LinkByName(hostVethName)
 	if err != nil {
@@ -298,6 +301,9 @@ func Add(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
+	if injectFailures {
+		panicForFirstRun("AfterMakingVethPair")
+	}
 
 	ip, err := getIPFromCoild(coildURL, podNS, podName, args.ContainerID)
 	if err != nil {
@@ -308,6 +314,9 @@ func Add(args *skel.CmdArgs) error {
 			returnIPToCoild(coildURL, podNS, podName, args.ContainerID)
 		}
 	}()
+	if injectFailures {
+		panicForFirstRun("AfterGettingIP")
+	}
 
 	err = addRouteInHost(ip, hostInterface.Name)
 	if err != nil {
@@ -327,6 +336,9 @@ func Add(args *skel.CmdArgs) error {
 	err = configureInterface(netns, args.IfName, result)
 	if err != nil {
 		return err
+	}
+	if injectFailures {
+		panicForFirstRun("AfterConfiguringInterfaces")
 	}
 
 	success = true

--- a/cni/del.go
+++ b/cni/del.go
@@ -31,6 +31,9 @@ func Del(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
+	if injectFailures {
+		panicForFirstRun("AfterReturingIP")
+	}
 
 	// Kubernetes sends multiple DEL for dead containers.
 	// See: https://github.com/kubernetes/kubernetes/issues/44100
@@ -41,6 +44,9 @@ func Del(args *skel.CmdArgs) error {
 	return ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
 		err := ip.DelLinkByName(args.IfName)
 		if err == nil || err == ip.ErrLinkNotFound {
+			if injectFailures {
+				panicForFirstRun("AfterDeletingVethPair")
+			}
 			return nil
 		}
 		return err

--- a/cni/failures_false.go
+++ b/cni/failures_false.go
@@ -1,0 +1,7 @@
+// +build !failures
+
+package cni
+
+const injectFailures = false
+
+func panicForFirstRun(name string) {}

--- a/cni/failures_true.go
+++ b/cni/failures_true.go
@@ -16,10 +16,10 @@ func panicForFirstRun(name string) {
 	fileName := filepath.Join("/tmp", "coil_failures_"+name)
 
 	_, err := os.Stat(fileName)
-	if os.IsNotExist(err) {
-		panic("injected failure: " + name)
+	if err == nil {
+		return
 	}
-	if err != nil {
+	if !os.IsNotExist(err) {
 		panic(err)
 	}
 
@@ -27,4 +27,5 @@ func panicForFirstRun(name string) {
 	if err != nil {
 		panic(err)
 	}
+	panic("injected failure: " + name)
 }

--- a/cni/failures_true.go
+++ b/cni/failures_true.go
@@ -1,0 +1,30 @@
+// +build failures
+
+package cni
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const injectFailures = true
+
+// panicForFirstRun panics at least for the first run.
+// This "first" is judged against the lifetime of "/tmp" files.
+// This does not consider race conditions.
+func panicForFirstRun(name string) {
+	fileName := filepath.Join("/tmp", "coil_failures_"+name)
+
+	_, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		panic("injected failure: " + name)
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = os.Create(fileName)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/docs/mtest.md
+++ b/docs/mtest.md
@@ -12,6 +12,10 @@ There are following types of test suites.
 
     This suite tests coil controller, coil installer, `coilctl` command and kubernetes workloads deployments.
 
+2. failures
+
+    This suite tests kubernetes workloads deployments under failure injection.
+
 Each test suite has an entry point of test as `<suite>/suite_test.go`.
 
 Synopsis
@@ -45,7 +49,7 @@ Options
 ### `SUITE`
 
 You can choose the type of test suite by specifying `SUITE` make variable.
-The value can be `functions` (default).
+The value can be `functions` (default) or `failures`.
 
 `make test` accepts this variable.
 

--- a/mtest/Makefile
+++ b/mtest/Makefile
@@ -29,6 +29,9 @@ ifeq ($(findstring /,$(SUITE)),)
 else
   SUITE_PACKAGE = $(SUITE)
 endif
+ifeq ($(SUITE_PACKAGE),./failures)
+  HYPERCOIL_TAGS := $(HYPERCOIL_TAGS) -tags failures
+endif
 
 # If you want to change the Kubernetes version for mtest, specify this variable from command line.
 # e.g. $ make KUBERNETES_VERSION=1.14 placemat
@@ -105,7 +108,7 @@ all:
 $(OUTPUT)/coil.img:
 	rm -rf tmpbin
 	mkdir tmpbin
-	cd ..; GOBIN=$(shell pwd)/tmpbin CGO_ENABLED=0 go install -mod=vendor ./pkg/hypercoil
+	cd ..; GOBIN=$(shell pwd)/tmpbin CGO_ENABLED=0 go install -mod=vendor $(HYPERCOIL_TAGS) ./pkg/hypercoil
 	ln -s hypercoil tmpbin/coil
 	ln -s hypercoil tmpbin/coild
 	ln -s hypercoil tmpbin/coil-controller

--- a/mtest/Makefile
+++ b/mtest/Makefile
@@ -116,7 +116,7 @@ $(OUTPUT)/coil.img:
 	ln -s hypercoil tmpbin/coil-installer
 	sudo docker build --no-cache --rm=false -f Dockerfile -t quay.io/cybozu/coil:dev tmpbin
 	mkdir -p $(OUTPUT)
-	sudo docker save -o $@ quay.io/cybozu/coil:dev
+	sudo docker save quay.io/cybozu/coil:dev > $@
 
 $(OUTPUT)/coilctl: $(OUTPUT)/coil.img
 	cp tmpbin/coilctl $@

--- a/mtest/failures.go
+++ b/mtest/failures.go
@@ -1,0 +1,86 @@
+package mtest
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestPodStartup tests pod startup, especially under failure injection.
+func TestPodStartup() {
+	BeforeEach(initializeCoil)
+	AfterEach(cleanCoil)
+
+	It("should confirm successful creation of CKE-managed pods", func() {
+		By("waiting for cluster-dns pods to become ready")
+		Eventually(func() error {
+			stdout, stderr, err := kubectl("get", "-n", "kube-system", "deployment", "cluster-dns", "-o", "json")
+			if err != nil {
+				return fmt.Errorf("err=%v, stdout=%s, stderr=%s", err, stdout, stderr)
+			}
+
+			deployment := new(appsv1.Deployment)
+			err = json.Unmarshal(stdout, deployment)
+			if err != nil {
+				return fmt.Errorf("err=%v, stdout=%s", err, stdout)
+			}
+
+			if deployment.Status.ReadyReplicas != 2 {
+				return errors.New("ReadyReplicas != 2")
+			}
+			return nil
+		}).Should(Succeed())
+	})
+
+	It("should starts up pod on half-cleaned node", func() {
+		By("making uncleaned veth artificially")
+		h := sha1.New()
+		h.Write([]byte("default.foo"))
+		vethName := "veth" + hex.EncodeToString(h.Sum(nil))[:11]
+		execSafeAt(node1, "sudo", "ip", "netns", "add", "foo")
+		execSafeAt(node1, "sudo", "ip", "netns", "exec", "foo", "ip", "link", "add", "eth0", "type", "veth", "peer", "name", vethName)
+		execSafeAt(node1, "sudo", "ip", "netns", "exec", "foo", "ip", "link", "set", vethName, "netns", "1")
+
+		By("creating pod with specific name on specific node")
+		podYAML := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: foo
+  namespace: default
+spec:
+  nodeName: %s
+  containers:
+  - name: nginx
+    image: nginx
+`
+		stdout, stderr, err := kubectlWithInput([]byte(fmt.Sprintf(podYAML, node1)), "apply", "-f", "-")
+		Expect(err).NotTo(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+
+		By("waiting for pod to become ready")
+		Eventually(func() error {
+			stdout, stderr, err := kubectl("get", "-n", "default", "pod", "foo", "-o", "json")
+			if err != nil {
+				return fmt.Errorf("err=%v, stdout=%s, stderr=%s", err, stdout, stderr)
+			}
+
+			pod := new(corev1.Pod)
+			err = json.Unmarshal(stdout, pod)
+			if err != nil {
+				return fmt.Errorf("err=%v, stdout=%s", err, stdout)
+			}
+
+			if pod.Status.Phase != corev1.PodRunning {
+				return errors.New("Phase != Running")
+			}
+			return nil
+		}).Should(Succeed())
+	})
+}

--- a/mtest/failures/suite_test.go
+++ b/mtest/failures/suite_test.go
@@ -1,0 +1,28 @@
+package mtest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cybozu-go/coil/mtest"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMtest(t *testing.T) {
+	if os.Getenv("SSH_PRIVKEY") == "" {
+		t.Skip("no SSH_PRIVKEY envvar")
+	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Multi-host test for coil")
+}
+
+var _ = BeforeSuite(func() {
+	mtest.RunBeforeSuite()
+})
+
+// This must be the only top-level test container.
+// Other tests and test containers must be listed in this.
+var _ = Describe("Test CKE functions", func() {
+	mtest.FailuresSuite()
+})

--- a/mtest/suites.go
+++ b/mtest/suites.go
@@ -12,5 +12,5 @@ var FunctionsSuite = func() {
 
 // FailuresSuite is a test suite that runs test cases with failure injection
 var FailuresSuite = func() {
-	Context("pod", TestPod)
+	Context("pod startup", TestPodStartup)
 }

--- a/mtest/suites.go
+++ b/mtest/suites.go
@@ -9,3 +9,8 @@ var FunctionsSuite = func() {
 	Context("pod", TestPod)
 	Context("pool", TestPool)
 }
+
+// FailuresSuite is a test suite that runs test cases with failure injection
+var FailuresSuite = func() {
+	Context("pod", TestPod)
+}


### PR DESCRIPTION
CNI plugin "coil" creates a veth pair for CNI "ADD" request.
The name of the host-side veth is generated deterministically.
This patch makes coil delete a host-side veth of the same name if exists.
