### PR TITLE
ci: extend gcp instance lifetime to 30min

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,11 @@ commands:
             ./bin/run-mtest.sh <<parameters.runtime>> <<parameters.suite>> <<parameters.kubernetes-version>>
           no_output_timeout: 20m
       - run:
-          name: Set the instance lifetime to 10 minutes
+          name: Set the instance lifetime
           command: |
             . ./bin/env
             $GCLOUD compute instances add-metadata ${INSTANCE_NAME} --zone ${ZONE} \
-              --metadata shutdown-at=$(date -Iseconds -d+10minutes)
+              --metadata shutdown-at=$(date -Iseconds -d+30minutes)
           when: on_fail
       - run:
           name: Notify to Slack


### PR DESCRIPTION
Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>