### PR TITLE
Implement coil-router

### DIFF
--- a/docs/cmd-coil-router.md
+++ b/docs/cmd-coil-router.md
@@ -1,0 +1,58 @@
+coil-router
+===========
+
+`coil-router` is an _optional_ program to setup the kernel routing table
+to route Pod packets between Nodes.  `coil-router` can be used only when
+all the nodes are in a flat layer-2 network.
+
+## How it works
+
+Coil allocates address blocks to Nodes.  Therefore, each node should receive
+packets to the addresses in the address blocks it owns.
+
+`coil-router` retrieves address block allocation information and configures
+the kernel routing table so that each address block are routed to their
+owning node.
+
+This behavior assumes that all the nodes are directly connected in a flat
+layer-2 network.
+
+## Environment variables
+
+`coil-router` references the following environment variables:
+
+| Name             | Required | Description                              |
+| ---------------- | -------- | ---------------------------------------- |
+| `COIL_NODE_NAME` | YES      | Kubernetes node name of the running node |
+
+## Command-line flags
+
+**CAVEAT**: `--protocol-id` value must be different from the value of `coild`.
+
+```
+Flags:
+      --health-addr string         bind address of health/readiness probes (default ":9389")
+  -h, --help                       help for coil-router
+      --metrics-addr string        bind address of metrics endpoint (default ":9388")
+      --protocol-id int            route author ID (default 31)
+      --update-interval duration   interval for forced route update (default 10m0s)
+  -v, --version                    version for coil-router
+```
+
+## Prometheus metrics
+
+### `coil_router_syncs_total`
+
+This is a counter of the total number of route synchronizations.
+
+| Label  | Description            |
+| ------ | ---------------------- |
+| `node` | The node resource name |
+
+### `coil_router_routes_synced`
+
+This is a gauge of the number of routes last synchronized to the kernel.
+
+| Label  | Description            |
+| ------ | ---------------------- |
+| `node` | The node resource name |

--- a/v2/cmd/coil-router/main.go
+++ b/v2/cmd/coil-router/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/cybozu-go/coil/v2/cmd/coil-router/sub"
+
+func main() {
+	sub.Execute()
+}

--- a/v2/cmd/coil-router/sub/root.go
+++ b/v2/cmd/coil-router/sub/root.go
@@ -1,0 +1,51 @@
+package sub
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	v2 "github.com/cybozu-go/coil/v2"
+	"github.com/spf13/cobra"
+)
+
+var config struct {
+	metricsAddr    string
+	healthAddr     string
+	protocolId     int
+	updateInterval time.Duration
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "coil-router",
+	Short: "a simple routing program for Coil",
+	Long: `coil-router programs Linux kernel routing table to route
+Pod packets between nodes.
+
+coil-router does not speak any routing protocol such as BGP.
+Instead, it directly insert routes corresponding to AddressBlocks
+owned by other Nodes.  This means that coil-router can be used
+only for clusters where all the nodes are in a flat L2 network.`,
+	Version: v2.Version(),
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		return subMain()
+	},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	pf := rootCmd.PersistentFlags()
+	pf.StringVar(&config.metricsAddr, "metrics-addr", ":9388", "bind address of metrics endpoint")
+	pf.StringVar(&config.healthAddr, "health-addr", ":9389", "bind address of health/readiness probes")
+	pf.IntVar(&config.protocolId, "protocol-id", 31, "route author ID")
+	pf.DurationVar(&config.updateInterval, "update-interval", 10*time.Minute, "interval for forced route update")
+}

--- a/v2/cmd/coil-router/sub/run.go
+++ b/v2/cmd/coil-router/sub/run.go
@@ -1,0 +1,72 @@
+package sub
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
+	"github.com/cybozu-go/coil/v2/controllers"
+	"github.com/cybozu-go/coil/v2/pkg/constants"
+	"github.com/cybozu-go/coil/v2/pkg/nodenet"
+	"github.com/cybozu-go/coil/v2/runners"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	gracefulTimeout = 5 * time.Second
+)
+
+func subMain() error {
+	ctrl.SetLogger(zap.New(zap.StacktraceLevel(zapcore.DPanicLevel)))
+
+	nodeName := os.Getenv(constants.EnvNode)
+	if nodeName == "" {
+		return errors.New(constants.EnvNode + " environment variable must be set")
+	}
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return err
+	}
+	if err := coilv2.AddToScheme(scheme); err != nil {
+		return err
+	}
+
+	timeout := gracefulTimeout
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                  scheme,
+		LeaderElection:          false,
+		MetricsBindAddress:      config.metricsAddr,
+		GracefulShutdownTimeout: &timeout,
+		HealthProbeBindAddress:  config.healthAddr,
+	})
+	if err != nil {
+		return err
+	}
+
+	notifyCh := make(chan struct{}, 1)
+	abr := &controllers.AddressBlockReconciler{Notify: notifyCh}
+	if err := abr.SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	syncer := nodenet.NewRouteSyncer(config.protocolId, ctrl.Log.WithName("route-syncer"))
+	router := runners.NewRouter(mgr, ctrl.Log.WithName("router"), nodeName, notifyCh, syncer, config.updateInterval)
+	if err := mgr.Add(router); err != nil {
+		return err
+	}
+
+	log := ctrl.Log.WithName("main")
+	log.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		log.Error(err, "problem running manager")
+		return err
+	}
+
+	return nil
+}

--- a/v2/cmd/coild/sub/run.go
+++ b/v2/cmd/coild/sub/run.go
@@ -9,6 +9,7 @@ import (
 
 	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
 	"github.com/cybozu-go/coil/v2/controllers"
+	"github.com/cybozu-go/coil/v2/pkg/constants"
 	"github.com/cybozu-go/coil/v2/pkg/ipam"
 	"github.com/cybozu-go/coil/v2/pkg/nodenet"
 	"github.com/cybozu-go/coil/v2/runners"
@@ -22,7 +23,6 @@ import (
 
 const (
 	gracefulTimeout = 20 * time.Second
-	nodeEnvName     = "COIL_NODE_NAME"
 )
 
 func subMain() error {
@@ -33,9 +33,9 @@ func subMain() error {
 	grpcLogger := zapLogger.Named("grpc")
 	ctrl.SetLogger(zapr.NewLogger(zapLogger))
 
-	nodeName := os.Getenv(nodeEnvName)
+	nodeName := os.Getenv(constants.EnvNode)
 	if nodeName == "" {
-		return errors.New(nodeEnvName + " environment variable should be set")
+		return errors.New(constants.EnvNode + " environment variable should be set")
 	}
 
 	scheme := runtime.NewScheme()

--- a/v2/controllers/addressblock_controller.go
+++ b/v2/controllers/addressblock_controller.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
+)
+
+// AddressBlockReconciler watches AddressBlocks and notifies a channel
+type AddressBlockReconciler struct {
+	Notify chan<- struct{}
+}
+
+var _ reconcile.Reconciler = &AddressBlockReconciler{}
+
+// +kubebuilder:rbac:groups=coil.cybozu.com,resources=addressblocks,verbs=get;list;watch
+
+// Reconcile implements Reconciler interface.
+func (r *AddressBlockReconciler) Reconcile(ctrl.Request) (ctrl.Result, error) {
+	select {
+	case r.Notify <- struct{}{}:
+	default:
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers this with the manager.
+func (r *AddressBlockReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&coilv2.AddressBlock{}).
+		Complete(r)
+}

--- a/v2/controllers/addressblock_controller_test.go
+++ b/v2/controllers/addressblock_controller_test.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("AddressBlock reconciler", func() {
+	ctx := context.Background()
+	var stopCh chan struct{}
+	notifyCh := make(chan struct{}, 100)
+
+	BeforeEach(func() {
+		stopCh = make(chan struct{})
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             scheme,
+			LeaderElection:     false,
+			MetricsBindAddress: "0",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		apr := AddressBlockReconciler{Notify: notifyCh}
+		err = apr.SetupWithManager(mgr)
+		Expect(err).ToNot(HaveOccurred())
+
+		go func() {
+			err := mgr.Start(stopCh)
+			if err != nil {
+				panic(err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+		time.Sleep(10 * time.Millisecond)
+	})
+
+	It("works as expected", func() {
+		By("checking the notification upon AddressBlock creation")
+		b := &coilv2.AddressBlock{}
+		b.Name = "notify-0"
+		err := k8sClient.Create(ctx, b)
+		Expect(err).To(Succeed())
+
+		Eventually(func() error {
+			select {
+			case <-notifyCh:
+				return nil
+			default:
+				time.Sleep(1 * time.Millisecond)
+				return errors.New("not yet notified")
+			}
+		}).Should(Succeed())
+	})
+})

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
+	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.13.0
 	github.com/pseudomuto/protoc-gen-doc v1.3.2

--- a/v2/pkg/constants/constants.go
+++ b/v2/pkg/constants/constants.go
@@ -28,6 +28,14 @@ const (
 	PodContainerKey = "K8S_POD_INFRA_CONTAINER_ID"
 )
 
+// Environment variables
+const (
+	EnvNode = "COIL_NODE_NAME"
+)
+
+// MetricsNS is the namespace for Prometheus metrics
+const MetricsNS = "coil"
+
 // Misc
 const (
 	DefaultPool = "default"

--- a/v2/pkg/nodenet/pod_test.go
+++ b/v2/pkg/nodenet/pod_test.go
@@ -264,4 +264,10 @@ func TestPodNetwork(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	// some cleanup
+	err = exec.Command("ip", "link", "del", "foo").Run()
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/v2/pkg/nodenet/route_syncer.go
+++ b/v2/pkg/nodenet/route_syncer.go
@@ -1,0 +1,86 @@
+package nodenet
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/vishvananda/netlink"
+)
+
+// GatewayInfo is a set of destination networks for a gateway.
+type GatewayInfo struct {
+	Gateway  net.IP
+	Networks []*net.IPNet
+}
+
+// RouteSyncer is the interface to program direct routing.
+type RouteSyncer interface {
+	// Sync synchronizes the kernel routing table with the given routes.
+	Sync([]GatewayInfo) error
+}
+
+// NewRouteSyncer creates a DirectRouter that marks routes with protocolId.
+//
+// protocolId must be different from the ID for NewPodNetwork.
+func NewRouteSyncer(protocolId int, log logr.Logger) RouteSyncer {
+	return &routeSyncer{
+		protocolId: protocolId,
+		log:        log,
+	}
+}
+
+type routeSyncer struct {
+	protocolId int
+	log        logr.Logger
+
+	mu sync.Mutex
+}
+
+func (d *routeSyncer) Sync(gis []GatewayInfo) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.log.Info("synchronizing the main routing table", "gateways", len(gis))
+	routes, err := netlink.RouteListFiltered(0, &netlink.Route{Protocol: d.protocolId}, netlink.RT_FILTER_PROTOCOL)
+	if err != nil {
+		return fmt.Errorf("netlink: failed to list routes: %w", err)
+	}
+
+	routeMap := make(map[string]*netlink.Route)
+	for _, gi := range gis {
+		strIP := gi.Gateway.String()
+		for _, n := range gi.Networks {
+			routeMap[strIP+" "+n.String()] = &netlink.Route{
+				Dst:      n,
+				Gw:       gi.Gateway,
+				Scope:    netlink.SCOPE_UNIVERSE,
+				Protocol: d.protocolId,
+			}
+		}
+	}
+
+	currentMap := make(map[string]bool)
+	for _, r := range routes {
+		key := r.Gw.String() + " " + r.Dst.String()
+		if _, ok := routeMap[key]; !ok {
+			if err := netlink.RouteDel(&r); err != nil {
+				return fmt.Errorf("netlink: failed to delete route: %w", err)
+			}
+			continue
+		}
+		currentMap[key] = true
+	}
+
+	for k, v := range routeMap {
+		if !currentMap[k] {
+			if err := netlink.RouteAdd(v); err != nil {
+				return fmt.Errorf("netlink: failed to add route to %s: %w", k, err)
+			}
+			d.log.Info("added", "dst", v.Dst.String())
+		}
+	}
+
+	return nil
+}

--- a/v2/pkg/nodenet/route_syncer_test.go
+++ b/v2/pkg/nodenet/route_syncer_test.go
@@ -1,0 +1,147 @@
+package nodenet
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func setupFake(t *testing.T) {
+	dummy := &netlink.Dummy{}
+	dummy.Name = "dummy"
+	if err := netlink.LinkAdd(dummy); err != nil {
+		t.Fatal(err)
+	}
+	dummyLink, err := netlink.LinkByName("dummy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := netlink.LinkSetUp(dummyLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// fake router addresses
+	if err := netlink.AddrAdd(dummyLink, &netlink.Addr{
+		IPNet: &net.IPNet{IP: net.ParseIP("10.9.0.1"), Mask: net.CIDRMask(24, 32)},
+		Scope: unix.RT_SCOPE_LINK,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := netlink.AddrAdd(dummyLink, &netlink.Addr{
+		IPNet: &net.IPNet{IP: net.ParseIP("fd09::1"), Mask: net.CIDRMask(120, 128)},
+		Scope: unix.RT_SCOPE_LINK,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ip.SettleAddresses("dummy", 10)
+
+	// existing route
+	if err := netlink.RouteAdd(&netlink.Route{
+		Dst:      netlink.NewIPNet(net.ParseIP("10.10.10.10")),
+		Gw:       net.ParseIP("127.0.0.1"),
+		Protocol: 2,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkRoutingTable(r RouteSyncer, expected []GatewayInfo) error {
+	if err := r.Sync(expected); err != nil {
+		return err
+	}
+
+	routes, err := netlink.RouteList(nil, 0)
+	if err != nil {
+		return err
+	}
+
+	routeMap := make(map[string]bool)
+	var nCoil int
+	for _, r := range routes {
+		routeMap[r.Gw.String()+" "+r.Dst.String()] = true
+		if r.Protocol == 31 {
+			nCoil++
+		}
+	}
+
+	if !routeMap[net.ParseIP("127.0.0.1").String()+" "+netlink.NewIPNet(net.ParseIP("10.10.10.10")).String()] {
+		return errors.New("intact route is not found: 10.10.10.10")
+	}
+
+	for _, gi := range expected {
+		gwStr := gi.Gateway.String()
+		for _, n := range gi.Networks {
+			if !routeMap[gwStr+" "+n.String()] {
+				return fmt.Errorf("expected route %s for %s not found", n.String(), gwStr)
+			}
+			nCoil--
+		}
+	}
+
+	if nCoil != 0 {
+		return fmt.Errorf("some routes were not deleted: %d", nCoil)
+	}
+	return nil
+}
+
+func TestRouteSyncer(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("need root privilege")
+	}
+	if os.Getenv("CIRCLECI") == "true" {
+		t.Skip("could not run on CircleCI")
+	}
+
+	setupFake(t)
+
+	r := NewRouteSyncer(31, ctrl.Log.WithName("test"))
+
+	gws := []GatewayInfo{
+		{net.ParseIP("10.9.0.2"), []*net.IPNet{
+			{IP: net.ParseIP("192.168.1.0"), Mask: net.CIDRMask(24, 32)},
+			{IP: net.ParseIP("192.168.2.0"), Mask: net.CIDRMask(24, 32)},
+		}},
+		{net.ParseIP("fd09::2"), []*net.IPNet{
+			{IP: net.ParseIP("fd03::0100"), Mask: net.CIDRMask(120, 128)},
+			{IP: net.ParseIP("fd03::0200"), Mask: net.CIDRMask(120, 128)},
+		}},
+	}
+	if err := checkRoutingTable(r, gws); err != nil {
+		t.Fatal(err)
+	}
+
+	gws = []GatewayInfo{
+		{net.ParseIP("10.9.0.2"), []*net.IPNet{
+			{IP: net.ParseIP("192.168.2.0"), Mask: net.CIDRMask(24, 32)},
+		}},
+		{net.ParseIP("fd09::2"), []*net.IPNet{
+			{IP: net.ParseIP("fd03::0100"), Mask: net.CIDRMask(120, 128)},
+			{IP: net.ParseIP("fd03::0200"), Mask: net.CIDRMask(120, 128)},
+		}},
+	}
+	if err := checkRoutingTable(r, gws); err != nil {
+		t.Fatal(err)
+	}
+
+	gws = []GatewayInfo{
+		{net.ParseIP("10.9.0.2"), []*net.IPNet{
+			{IP: net.ParseIP("192.168.2.0"), Mask: net.CIDRMask(24, 32)},
+		}},
+		{net.ParseIP("10.9.0.3"), []*net.IPNet{
+			{IP: net.ParseIP("192.168.1.0"), Mask: net.CIDRMask(24, 32)},
+		}},
+		{net.ParseIP("fd09::2"), []*net.IPNet{
+			{IP: net.ParseIP("fd03::0100"), Mask: net.CIDRMask(120, 128)},
+		}},
+	}
+	if err := checkRoutingTable(r, gws); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/v2/runners/coild_server_test.go
+++ b/v2/runners/coild_server_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cybozu-go/coil/v2/pkg/nodenet"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/vishvananda/netlink"
 	"go.uber.org/zap/zapcore"
@@ -383,20 +382,3 @@ var _ = Describe("Coild server", func() {
 		Expect(err).To(HaveOccurred())
 	})
 })
-
-func findMetric(mf *dto.MetricFamily, labels map[string]string) *dto.Metric {
-OUTER:
-	for _, m := range mf.Metric {
-		having := make(map[string]string)
-		for _, p := range m.Label {
-			having[*p.Name] = *p.Value
-		}
-		for k, v := range labels {
-			if having[k] != v {
-				continue OUTER
-			}
-		}
-		return m
-	}
-	return nil
-}

--- a/v2/runners/garbage_collector_test.go
+++ b/v2/runners/garbage_collector_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Garbage collector", func() {
 	})
 
 	AfterEach(func() {
+		deleteAllAddressBlocks()
 		close(stopCh)
 		err := k8sClient.DeleteAllOf(ctx, &coilv2.BlockRequest{})
 		Expect(err).To(Succeed())

--- a/v2/runners/router.go
+++ b/v2/runners/router.go
@@ -1,0 +1,202 @@
+package runners
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
+	"github.com/cybozu-go/coil/v2/pkg/constants"
+	"github.com/cybozu-go/coil/v2/pkg/nodenet"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	initOnce   sync.Once
+	syncCount  prometheus.Counter
+	routeGauge prometheus.Gauge
+)
+
+func initMetrics(nodeName string) {
+	initOnce.Do(func() {
+		syncCount = prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   constants.MetricsNS,
+			Subsystem:   "router",
+			Name:        "syncs_total",
+			Help:        "Number of times coil-router has synchronized routes",
+			ConstLabels: prometheus.Labels{"node": nodeName},
+		})
+		metrics.Registry.MustRegister(syncCount)
+
+		routeGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace:   constants.MetricsNS,
+			Subsystem:   "router",
+			Name:        "routes_synced",
+			Help:        "Number of routes synchronized to kernel",
+			ConstLabels: prometheus.Labels{"node": nodeName},
+		})
+
+		metrics.Registry.MustRegister(routeGauge)
+	})
+}
+
+// NewRouter creates a manager.Runnable for coil-router.
+func NewRouter(mgr manager.Manager, log logr.Logger, nodeName string, notifyCh <-chan struct{}, syncer nodenet.RouteSyncer, interval time.Duration) manager.Runnable {
+	return &router{
+		Client:    mgr.GetClient(),
+		apiReader: mgr.GetAPIReader(),
+		log:       log,
+		nodeName:  nodeName,
+		notifyCh:  notifyCh,
+		syncer:    syncer,
+		interval:  interval,
+	}
+}
+
+type router struct {
+	client.Client
+	apiReader client.Reader
+	log       logr.Logger
+	nodeName  string
+	notifyCh  <-chan struct{}
+	syncer    nodenet.RouteSyncer
+	interval  time.Duration
+}
+
+// +kubebuilder:rbac:groups=coil.cybozu.com,resources=addressblocks,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=list
+
+var _ manager.LeaderElectionRunnable = &router{}
+
+// NeedLeaderElection implements manager.LeaderElectionRunnable
+func (r *router) NeedLeaderElection() bool {
+	return false
+}
+
+func (r *router) Start(done <-chan struct{}) error {
+	initMetrics(r.nodeName)
+
+	tick := time.NewTicker(r.interval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-done:
+			return nil
+		case <-r.notifyCh:
+		case <-tick.C:
+		}
+		if err := r.sync(context.Background()); err != nil {
+			r.log.Error(err, "synchronizing block information failed")
+			return err
+		}
+		syncCount.Add(1)
+	}
+}
+
+type nodeIP struct {
+	IPv4 net.IP
+	IPv6 net.IP
+}
+
+func (r *router) sync(ctx context.Context) error {
+	nodes := &corev1.NodeList{}
+	if err := r.apiReader.List(ctx, nodes); err != nil {
+		return fmt.Errorf("failed to list Nodes: %w", err)
+	}
+	nodeMap := make(map[string]nodeIP)
+	for _, n := range nodes.Items {
+		if n.Name == r.nodeName {
+			// ignore the running node
+			continue
+		}
+
+		var ipv4, ipv6 net.IP
+		for _, a := range n.Status.Addresses {
+			if a.Type != corev1.NodeInternalIP {
+				continue
+			}
+			ip := net.ParseIP(a.Address)
+			if ip.To4() != nil {
+				ipv4 = ip.To4()
+				continue
+			}
+			if ip.To16() != nil {
+				ipv6 = ip.To16()
+			}
+		}
+		nodeMap[n.Name] = nodeIP{IPv4: ipv4, IPv6: ipv6}
+	}
+
+	blocks := &coilv2.AddressBlockList{}
+	if err := r.Client.List(ctx, blocks); err != nil {
+		return fmt.Errorf("failed to list AddressBlocks: %w", err)
+	}
+	nRoutes := 0
+	giMap := make(map[string]*nodenet.GatewayInfo)
+	for _, b := range blocks.Items {
+		nodeName := b.Labels[constants.LabelNode]
+		nm, ok := nodeMap[nodeName]
+		if !ok {
+			// node might be deleted
+			continue
+		}
+
+		if b.IPv4 != nil {
+			_, n, _ := net.ParseCIDR(*b.IPv4)
+			gw := nm.IPv4
+			if gw == nil {
+				r.log.Info("node has no IPv4 address", "node", nodeName)
+				goto IPv6
+			}
+
+			nRoutes++
+			gwStr := gw.String()
+			if gi, ok := giMap[gwStr]; ok {
+				gi.Networks = append(gi.Networks, n)
+			} else {
+				giMap[gwStr] = &nodenet.GatewayInfo{
+					Gateway:  gw,
+					Networks: []*net.IPNet{n},
+				}
+			}
+		}
+
+	IPv6:
+		if b.IPv6 != nil {
+			_, n, _ := net.ParseCIDR(*b.IPv6)
+			gw := nm.IPv6
+			if gw == nil {
+				r.log.Info("node has no IPv6 address", "node", nodeName)
+				continue
+			}
+
+			nRoutes++
+			gwStr := gw.String()
+			if gi, ok := giMap[gwStr]; ok {
+				gi.Networks = append(gi.Networks, n)
+			} else {
+				giMap[gwStr] = &nodenet.GatewayInfo{
+					Gateway:  gw,
+					Networks: []*net.IPNet{n},
+				}
+			}
+		}
+	}
+
+	routeGauge.Set(float64(nRoutes))
+
+	gis := make([]nodenet.GatewayInfo, 0, len(giMap))
+	for _, gi := range giMap {
+		gis = append(gis, *gi)
+	}
+
+	return r.syncer.Sync(gis)
+}

--- a/v2/runners/router_test.go
+++ b/v2/runners/router_test.go
@@ -1,0 +1,192 @@
+package runners
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
+	"github.com/cybozu-go/coil/v2/pkg/constants"
+	"github.com/cybozu-go/coil/v2/pkg/nodenet"
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/expfmt"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type fakeSyncer struct {
+	ch chan<- map[string]nodenet.GatewayInfo
+}
+
+func (s *fakeSyncer) Sync(gis []nodenet.GatewayInfo) error {
+	m := make(map[string]nodenet.GatewayInfo)
+	for _, gi := range gis {
+		m[gi.Gateway.String()] = gi
+	}
+	s.ch <- m
+	return nil
+}
+
+func newIPNet(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	return n
+}
+
+func createBlock(ctx context.Context, name, nodeName string, ipv4, ipv6 *net.IPNet) {
+	block := &coilv2.AddressBlock{}
+	block.Name = name
+	block.Labels = map[string]string{constants.LabelNode: nodeName}
+	if ipv4 != nil {
+		s := ipv4.String()
+		block.IPv4 = &s
+	}
+	if ipv6 != nil {
+		s := ipv6.String()
+		block.IPv6 = &s
+	}
+	err := k8sClient.Create(ctx, block)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}
+
+var _ = Describe("Router", func() {
+	ctx := context.Background()
+	var stopCh chan struct{}
+	syncCh := make(chan struct{})
+	resultCh := make(chan map[string]nodenet.GatewayInfo)
+
+	BeforeEach(func() {
+		stopCh = make(chan struct{})
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             scheme,
+			LeaderElection:     false,
+			MetricsBindAddress: "localhost:13450",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		r := NewRouter(mgr, ctrl.Log.WithName("garbage collector"), "node1", syncCh, &fakeSyncer{ch: resultCh}, 1*time.Minute)
+		err = mgr.Add(r)
+		Expect(err).ToNot(HaveOccurred())
+
+		go func() {
+			err := mgr.Start(stopCh)
+			if err != nil {
+				panic(err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		deleteAllAddressBlocks()
+		close(stopCh)
+		time.Sleep(10 * time.Millisecond)
+	})
+
+	It("should convert address blocks to routes", func() {
+		By("synchronizing address blocks")
+		// node1 is the running node, so ignored
+		createBlock(ctx, "block-0", "node1", newIPNet("10.30.1.0/24"), newIPNet("fd02::0100/120"))
+		// node2 does not exist, so ignored
+		createBlock(ctx, "block-1", "node2", newIPNet("10.30.2.0/24"), newIPNet("fd02::0200/120"))
+		// node4 has only IPv4 address
+		createBlock(ctx, "block-2", "node4", newIPNet("10.30.4.0/24"), newIPNet("fd02::0400/120"))
+		// node5 has only IPv6 address
+		createBlock(ctx, "block-3", "node5", newIPNet("10.30.5.0/24"), newIPNet("fd02::0500/120"))
+		// node6 has both IPv4 and IPv6 addresses
+		createBlock(ctx, "block-4", "node6", newIPNet("10.30.6.0/24"), newIPNet("fd02::0600/120"))
+
+		Eventually(func() error {
+			syncCh <- struct{}{}
+			result := <-resultCh
+
+			if _, ok := result[net.ParseIP("10.20.30.41").String()]; ok {
+				return fmt.Errorf("should not have 10.20.30.41: %v", result)
+			}
+			if _, ok := result[net.ParseIP("fd10::41").String()]; ok {
+				return fmt.Errorf("should not have fd10::41: %v", result)
+			}
+			if _, ok := result[net.ParseIP("fd10::44").String()]; !ok {
+				return fmt.Errorf("should have fd10::44: %v", result)
+			}
+			if _, ok := result[net.ParseIP("10.20.30.45").String()]; !ok {
+				return fmt.Errorf("should have 10.20.30.45: %v", result)
+			}
+			if _, ok := result[net.ParseIP("10.20.30.46").String()]; !ok {
+				return fmt.Errorf("should have 10.20.30.46: %v", result)
+			}
+			if _, ok := result[net.ParseIP("fd10::46").String()]; !ok {
+				return fmt.Errorf("should have fd10::46: %v", result)
+			}
+
+			nets := result[net.ParseIP("fd10::44").String()].Networks
+			expected := []*net.IPNet{newIPNet("fd02::0400/120")}
+			if !cmp.Equal(nets, expected) {
+				return fmt.Errorf("unexpected networks: %v", cmp.Diff(nets, expected))
+			}
+
+			nets = result[net.ParseIP("10.20.30.45").String()].Networks
+			expected = []*net.IPNet{newIPNet("10.30.5.0/24")}
+			if !cmp.Equal(nets, expected) {
+				return fmt.Errorf("unexpected networks: %v", cmp.Diff(nets, expected))
+			}
+
+			return nil
+		}).Should(Succeed())
+
+		By("adding more blocks")
+		createBlock(ctx, "block-5", "node6", newIPNet("10.30.7.0/24"), nil)
+		createBlock(ctx, "block-6", "node6", nil, newIPNet("fd02::0800/120"))
+
+		Eventually(func() error {
+			syncCh <- struct{}{}
+			result := <-resultCh
+
+			if _, ok := result[net.ParseIP("10.20.30.41").String()]; ok {
+				return fmt.Errorf("should not have 10.20.30.41: %v", result)
+			}
+			if _, ok := result[net.ParseIP("fd10::41").String()]; ok {
+				return fmt.Errorf("should not have fd10::41: %v", result)
+			}
+
+			nets := result[net.ParseIP("10.20.30.46").String()].Networks
+			expected := []*net.IPNet{newIPNet("10.30.6.0/24"), newIPNet("10.30.7.0/24")}
+			if !cmp.Equal(nets, expected) {
+				return fmt.Errorf("unexpected networks: %v", cmp.Diff(nets, expected))
+			}
+
+			nets = result[net.ParseIP("fd10::46").String()].Networks
+			expected = []*net.IPNet{newIPNet("fd02::0600/120"), newIPNet("fd02::0800/120")}
+			if !cmp.Equal(nets, expected) {
+				return fmt.Errorf("unexpected networks: %v", cmp.Diff(nets, expected))
+			}
+
+			return nil
+		}).Should(Succeed())
+
+		By("checking metrics")
+		resp, err := http.Get("http://localhost:13450/metrics")
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		mfs, err := (&expfmt.TextParser{}).TextToMetricFamilies(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(mfs).To(HaveKey("coil_router_syncs_total"))
+		mf := mfs["coil_router_syncs_total"]
+		metric := findMetric(mf, map[string]string{
+			"node": "node1",
+		})
+		Expect(metric).NotTo(BeNil())
+		Expect(metric.GetCounter().GetValue()).To(BeNumerically(">=", 2))
+
+		Expect(mfs).To(HaveKey("coil_router_routes_synced"))
+		mf = mfs["coil_router_routes_synced"]
+		metric = findMetric(mf, map[string]string{
+			"node": "node1",
+		})
+		Expect(metric).NotTo(BeNil())
+		Expect(metric.GetGauge().GetValue()).To(BeNumerically("==", 6))
+	})
+})


### PR DESCRIPTION
`coil-router` is an optional component of Coil.
It programs the kernel routing table so that it can send packets directly to Pods running on other nodes.

This is only for environments where all the nodes are in a flat L2 network.