### PR TITLE
NAT using Foo-over-UDP

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
       - run: make test
       - run: make test-nodenet
         timeout-minutes: 10
+      - run: make test-founat
+        timeout-minutes: 10
       - run: make check-generate
   e2e:
     name: End-to-end Test

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -1,3 +1,6 @@
 FROM scratch
 
+# https://docs.github.com/en/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
+LABEL org.opencontainers.image.source https://github.com/cybozu-go/coil
+
 COPY /work /

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -16,7 +16,11 @@ GO111MODULE=on
 KUBEBUILDER_ASSETS := $(PWD)/bin
 PROTOC := PATH=$(PWD)/bin:$(PATH) $(PWD)/bin/protoc -I=$(PWD)/include:.
 PODNSLIST = pod1 pod2 pod3
-export GO111MODULE KUBEBUILDER_ASSETS PODNSLIST
+NATNSLIST = nat-client nat-router nat-egress nat-target
+OTHERNSLIST = test-egress-dual test-egress-v4 test-egress-v6 \
+	test-client-dual test-client-v4 test-client-v6 test-client-custom \
+	test-fou-dual test-fou-v4 test-fou-v6
+export GO111MODULE KUBEBUILDER_ASSETS
 
 .PHONY: test
 test: test-tools
@@ -34,8 +38,18 @@ test-nodenet:
 	for i in $@ $(PODNSLIST); do $(SUDO) ip netns add $$i; done
 	for i in $@ $(PODNSLIST); do $(SUDO) ip netns exec $$i ip link set lo up; done
 	$(SUDO) ip netns exec $@ ./nodenet.test -test.v
-	#for i in $@ $(PODNSLIST); do $(SUDO) ip netns delete $$i; done
+	for i in $@ $(PODNSLIST); do $(SUDO) ip netns delete $$i; done
 	rm -f nodenet.test
+
+.PHONY: test-founat
+test-founat:
+	go test -c ./pkg/founat
+	for i in $(NATNSLIST) $(OTHERNSLIST); do $(SUDO) ip netns delete $$i 2>/dev/null || true; done
+	for i in $(NATNSLIST) $(OTHERNSLIST); do $(SUDO) ip netns add $$i; done
+	for i in $(NATNSLIST) $(OTHERNSLIST); do $(SUDO) ip netns exec $$i ip link set lo up; done
+	$(SUDO) ./founat.test -test.v
+	#for i in $(NATNSLIST) $(OTHERNSLIST); do $(SUDO) ip netns delete $$i; done
+	rm -f founat.test
 
 .PHONY: check-generate
 check-generate:

--- a/v2/e2e/README.md
+++ b/v2/e2e/README.md
@@ -82,7 +82,7 @@ Other functions can be tested straightforwardly.
 
 ## Implementation
 
-The end-to-end tests are run on [kind, or Kubernetes IN Docker][].
+The end-to-end tests are run on [kind, or Kubernetes IN Docker][kind].
 kind can create mutli-node clusters without installing CNI plugin.
 
 To run e2e tests, prepare Docker and run the following commands.
@@ -96,7 +96,7 @@ $ make test
 You may change the default Kubernetes image for kind with `IMAGE` option.
 
 ```console
-$ make start IMAGE=kindest/node:v1.19.0
+$ make start IMAGE=kindest/node:v1.19.1
 ```
 
 To stop the cluster, run `make stop`.

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.8.7
+	github.com/coreos/go-iptables v0.4.5
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1
 	github.com/golang/protobuf v1.4.2
@@ -23,7 +24,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
-	github.com/vishvananda/netlink v1.1.0
+	github.com/vishvananda/netlink v1.1.1-0.20200915183220-339a215d6544
 	github.com/willf/bitset v1.1.11
 	go.uber.org/zap v1.15.0
 	golang.org/x/sys v0.0.0-20200828194041-157a740278f4

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -35,6 +35,6 @@ require (
 	k8s.io/apimachinery v0.18.8
 	k8s.io/client-go v0.18.8
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 // indirect
-	sigs.k8s.io/controller-runtime v0.6.2
+	sigs.k8s.io/controller-runtime v0.6.3
 	sigs.k8s.io/controller-tools v0.4.0
 )

--- a/v2/pkg/founat/client.go
+++ b/v2/pkg/founat/client.go
@@ -1,0 +1,216 @@
+package founat
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/vishvananda/netlink"
+)
+
+// IDs
+const (
+	ncProtocolID    = 30
+	ncNarrowTableID = 117
+	ncWideTableID   = 118
+
+	mainTableID = 254
+)
+
+// rule priorities
+const (
+	ncLinkLocalPrio = 1800
+	ncNarrowPrio    = 1900
+	ncLocalPrioBase = 2000
+	ncWidePrio      = 2100
+)
+
+// special subnets
+var (
+	v4PrivateList = []*net.IPNet{
+		{IP: net.ParseIP("10.0.0.0").To4(), Mask: net.CIDRMask(8, 32)},
+		{IP: net.ParseIP("172.16.0.0").To4(), Mask: net.CIDRMask(12, 32)},
+		{IP: net.ParseIP("192.168.0.0").To4(), Mask: net.CIDRMask(16, 32)},
+	}
+
+	v6PrivateList = []*net.IPNet{
+		{IP: net.ParseIP("fc00::"), Mask: net.CIDRMask(7, 128)},
+	}
+
+	v4LinkLocal = &net.IPNet{IP: net.ParseIP("169.254.0.0"), Mask: net.CIDRMask(16, 32)}
+
+	v6LinkLocal = &net.IPNet{IP: net.ParseIP("fe80::"), Mask: net.CIDRMask(10, 128)}
+)
+
+// NatClient represents the interface for NAT client
+type NatClient interface {
+	Init() error
+	AddEgress(link netlink.Link, subnets []*net.IPNet) error
+}
+
+// NewNatClient creates a NatClient.
+//
+// `ipv4` and `ipv6` are IPv4 and IPv6 addresses of the client pod.
+// Either one of them can be nil.
+//
+// `podNodeNet` is, if given, are networks for Pod and Node addresses.
+// If all the addresses of Pods and Nodes are within IPv4/v6 private addresses,
+// `podNodeNet` can be left nil.
+func NewNatClient(ipv4, ipv6 net.IP, podNodeNet []*net.IPNet) NatClient {
+	if ipv4 != nil && ipv4.To4() == nil {
+		panic("invalid IPv4 address")
+	}
+	if ipv6 != nil && ipv6.To4() != nil {
+		panic("invalid IPv6 address")
+	}
+
+	var v4priv, v6priv []*net.IPNet
+	if len(podNodeNet) > 0 {
+		for _, n := range podNodeNet {
+			if _, bits := n.Mask.Size(); bits == 32 {
+				v4priv = append(v4priv, n)
+			} else {
+				v6priv = append(v6priv, n)
+			}
+		}
+	} else {
+		v4priv = v4PrivateList
+		v6priv = v6PrivateList
+	}
+
+	return &natClient{
+		ipv4:   ipv4 != nil,
+		ipv6:   ipv6 != nil,
+		v4priv: v4priv,
+		v6priv: v6priv,
+	}
+}
+
+type natClient struct {
+	ipv4 bool
+	ipv6 bool
+
+	v4priv []*net.IPNet
+	v6priv []*net.IPNet
+
+	mu sync.Mutex
+}
+
+func newRuleForClient(family, table, prio int) *netlink.Rule {
+	r := netlink.NewRule()
+	r.Family = family
+	r.Table = table
+	r.Priority = prio
+	return r
+}
+
+func (c *natClient) Init() error {
+	if c.ipv4 {
+		linkLocalRule := newRuleForClient(netlink.FAMILY_V4, mainTableID, ncLinkLocalPrio)
+		linkLocalRule.Dst = v4LinkLocal
+		if err := netlink.RuleAdd(linkLocalRule); err != nil {
+			return fmt.Errorf("netlink: failed to add v4 link local rule: %w", err)
+		}
+
+		narrowRule := newRuleForClient(netlink.FAMILY_V4, ncNarrowTableID, ncNarrowPrio)
+		if err := netlink.RuleAdd(narrowRule); err != nil {
+			return fmt.Errorf("netlink: failed to add v4 narrow rule: %w", err)
+		}
+
+		for i, n := range c.v4priv {
+			r := newRuleForClient(netlink.FAMILY_V4, mainTableID, ncLocalPrioBase+i)
+			r.Dst = n
+			if err := netlink.RuleAdd(r); err != nil {
+				return fmt.Errorf("netlink: failed to add %s to rule: %w", n.String(), err)
+			}
+		}
+
+		wideRule := newRuleForClient(netlink.FAMILY_V4, ncWideTableID, ncWidePrio)
+		if err := netlink.RuleAdd(wideRule); err != nil {
+			return fmt.Errorf("netlink: failed to add v4 wide rule: %w", err)
+		}
+	}
+
+	if c.ipv6 {
+		linkLocalRule := newRuleForClient(netlink.FAMILY_V6, mainTableID, ncLinkLocalPrio)
+		linkLocalRule.Dst = v6LinkLocal
+		if err := netlink.RuleAdd(linkLocalRule); err != nil {
+			return fmt.Errorf("netlink: failed to add v6 link local rule: %w", err)
+		}
+
+		narrowRule := newRuleForClient(netlink.FAMILY_V6, ncNarrowTableID, ncNarrowPrio)
+		if err := netlink.RuleAdd(narrowRule); err != nil {
+			return fmt.Errorf("netlink: failed to add v6 narrow rule: %w", err)
+		}
+
+		for i, n := range c.v6priv {
+			r := newRuleForClient(netlink.FAMILY_V6, mainTableID, ncLocalPrioBase+i)
+			r.Dst = n
+			if err := netlink.RuleAdd(r); err != nil {
+				return fmt.Errorf("netlink: failed to add %s to rule: %w", n.String(), err)
+			}
+		}
+
+		wideRule := newRuleForClient(netlink.FAMILY_V6, ncWideTableID, ncWidePrio)
+		if err := netlink.RuleAdd(wideRule); err != nil {
+			return fmt.Errorf("netlink: failed to add v6 wide rule: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *natClient) AddEgress(link netlink.Link, subnets []*net.IPNet) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, n := range subnets {
+		if err := c.addEgress1(link, n); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *natClient) addEgress1(link netlink.Link, n *net.IPNet) error {
+	var priv []*net.IPNet
+	if n.IP.To4() != nil {
+		if !c.ipv4 {
+			return nil
+		}
+		priv = c.v4priv
+	} else {
+		if !c.ipv6 {
+			return nil
+		}
+		priv = c.v6priv
+	}
+
+	for _, p := range priv {
+		if !p.Contains(n.IP) {
+			continue
+		}
+
+		err := netlink.RouteAdd(&netlink.Route{
+			Table:     ncNarrowTableID,
+			Dst:       n,
+			LinkIndex: link.Attrs().Index,
+			Protocol:  ncProtocolID,
+		})
+		if err != nil {
+			return fmt.Errorf("netlink: failed to add route to %s: %w", n.String(), err)
+		}
+		return nil
+	}
+
+	err := netlink.RouteAdd(&netlink.Route{
+		Table:     ncWideTableID,
+		Dst:       n,
+		LinkIndex: link.Attrs().Index,
+		Protocol:  ncProtocolID,
+	})
+	if err != nil {
+		return fmt.Errorf("netlink: failed to add route to %s: %w", n.String(), err)
+	}
+	return nil
+}

--- a/v2/pkg/founat/client_test.go
+++ b/v2/pkg/founat/client_test.go
@@ -1,0 +1,386 @@
+package founat
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+func TestClient(t *testing.T) {
+	t.Run("Default", testClientDual)
+	t.Run("IPv4", testClientV4)
+	t.Run("IPv6", testClientV6)
+	t.Run("Custom", testClientCustom)
+}
+
+func ruleMap(family int) (map[int]*netlink.Rule, error) {
+	rules, err := netlink.RuleList(family)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[int]*netlink.Rule)
+	for _, r := range rules {
+		r := r
+		m[r.Priority] = &r
+	}
+	return m, nil
+}
+
+func testClientDual(t *testing.T) {
+	t.Parallel()
+
+	cNS, err := ns.GetNS("/run/netns/test-client-dual")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cNS.Close()
+
+	err = cNS.Do(func(ns.NetNS) error {
+		nc := NewNatClient(net.ParseIP("10.1.1.1"), net.ParseIP("fd02::1"), nil)
+		if err := nc.Init(); err != nil {
+			return err
+		}
+
+		rm, err := ruleMap(netlink.FAMILY_V4)
+		if err != nil {
+			return err
+		}
+		if r, ok := rm[1800]; !ok {
+			return errors.New("no ipv4 link local rule")
+		} else {
+			if r.Table != 254 {
+				return errors.New("link local rule should point the main table")
+			}
+		}
+		if r, ok := rm[1900]; !ok {
+			return errors.New("no ipv4 narrow rule")
+		} else {
+			if r.Table != 117 {
+				return errors.New("narrow rule should point routing table 117")
+			}
+		}
+		if r, ok := rm[2000]; !ok {
+			return errors.New("no rule for IPv4 private networks")
+		} else {
+			if r.Table != 254 {
+				return errors.New("private network rule should point the main table")
+			}
+		}
+		if _, ok := rm[2002]; !ok {
+			return errors.New("no rule exists for priority 2002")
+		}
+		if r, ok := rm[2100]; !ok {
+			return errors.New("no ipv4 wide rule")
+		} else {
+			if r.Table != 118 {
+				return errors.New("wide rule should point routing table 118")
+			}
+		}
+
+		rm, err = ruleMap(netlink.FAMILY_V6)
+		if err != nil {
+			return err
+		}
+		if r, ok := rm[1800]; !ok {
+			return errors.New("no ipv6 link local rule")
+		} else {
+			if r.Table != 254 {
+				return errors.New("link local rule should point the main table")
+			}
+		}
+		if r, ok := rm[1900]; !ok {
+			return errors.New("no ipv6 narrow rule")
+		} else {
+			if r.Table != 117 {
+				return errors.New("narrow rule should point routing table 117")
+			}
+		}
+		if r, ok := rm[2000]; !ok {
+			return errors.New("no rule for IPv6 private networks")
+		} else {
+			if r.Table != 254 {
+				return errors.New("private network rule should point the main table")
+			}
+		}
+		if r, ok := rm[2100]; !ok {
+			return errors.New("no ipv6 wide rule")
+		} else {
+			if r.Table != 118 {
+				return errors.New("wide rule should point routing table 118")
+			}
+		}
+
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		dummy := &netlink.Dummy{LinkAttrs: attrs}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("failed to add dummy link: %w", err)
+		}
+		link, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return fmt.Errorf("failed to get dummy1: %w", err)
+		}
+		err = nc.AddEgress(link, []*net.IPNet{
+			{IP: net.ParseIP("10.1.2.0"), Mask: net.CIDRMask(24, 32)},
+			{IP: net.ParseIP("0.0.0.0"), Mask: net.CIDRMask(0, 32)},
+			{IP: net.ParseIP("fd02::"), Mask: net.CIDRMask(64, 128)},
+			{IP: net.ParseIP("::"), Mask: net.CIDRMask(0, 128)},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add egress: %w", err)
+		}
+
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 1 {
+			return errors.New("failed to add ipv4 dst to table 117")
+		}
+		if !routes[0].Dst.IP.Equal(net.ParseIP("10.1.2.0")) {
+			return fmt.Errorf("wrong dst in table 117: %s", routes[0].Dst.String())
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 118}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 1 {
+			return errors.New("failed to add ipv4 dst to table 118")
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+
+		if len(routes) != 1 {
+			return errors.New("failed to add ipv6 dst to table 117")
+		}
+		if !routes[0].Dst.IP.Equal(net.ParseIP("fd02::")) {
+			return fmt.Errorf("wrong dst in table 117: %s", routes[0].Dst.String())
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 118}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 1 {
+			return errors.New("failed to add ipv6 dst to table 118")
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func testClientV4(t *testing.T) {
+	t.Parallel()
+
+	cNS, err := ns.GetNS("/run/netns/test-client-v4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cNS.Close()
+
+	err = cNS.Do(func(ns.NetNS) error {
+		nc := NewNatClient(net.ParseIP("10.1.1.1"), nil, nil)
+		if err := nc.Init(); err != nil {
+			return err
+		}
+
+		rm, err := ruleMap(netlink.FAMILY_V4)
+		if err != nil {
+			return err
+		}
+		if _, ok := rm[1800]; !ok {
+			return errors.New("no ipv4 link local rule")
+		}
+
+		rm, err = ruleMap(netlink.FAMILY_V6)
+		if err != nil {
+			return err
+		}
+		if _, ok := rm[1800]; ok {
+			return errors.New("ipv6 link local rule exists")
+		}
+
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		dummy := &netlink.Dummy{LinkAttrs: attrs}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("failed to add dummy link: %w", err)
+		}
+		link, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return fmt.Errorf("failed to get dummy1: %w", err)
+		}
+		err = nc.AddEgress(link, []*net.IPNet{
+			{IP: net.ParseIP("10.1.2.0"), Mask: net.CIDRMask(24, 32)},
+			{IP: net.ParseIP("0.0.0.0"), Mask: net.CIDRMask(0, 32)},
+			{IP: net.ParseIP("fd02::"), Mask: net.CIDRMask(64, 128)},
+			{IP: net.ParseIP("::"), Mask: net.CIDRMask(0, 128)},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add egress: %w", err)
+		}
+
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 1 {
+			return errors.New("failed to add ipv4 dst to table 117")
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 0 {
+			return errors.New("ipv6 should be ignored")
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func testClientV6(t *testing.T) {
+	t.Parallel()
+
+	cNS, err := ns.GetNS("/run/netns/test-client-v6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cNS.Close()
+
+	err = cNS.Do(func(ns.NetNS) error {
+		nc := NewNatClient(nil, net.ParseIP("fd02::1"), nil)
+		if err := nc.Init(); err != nil {
+			return err
+		}
+
+		rm, err := ruleMap(netlink.FAMILY_V4)
+		if err != nil {
+			return err
+		}
+		if _, ok := rm[1800]; ok {
+			return errors.New("ipv4 link local rule exists")
+		}
+
+		rm, err = ruleMap(netlink.FAMILY_V6)
+		if err != nil {
+			return err
+		}
+		if _, ok := rm[1800]; !ok {
+			return errors.New("no ipv6 link local rule")
+		}
+
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		dummy := &netlink.Dummy{LinkAttrs: attrs}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("failed to add dummy link: %w", err)
+		}
+		link, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return fmt.Errorf("failed to get dummy1: %w", err)
+		}
+		err = nc.AddEgress(link, []*net.IPNet{
+			{IP: net.ParseIP("10.1.2.0"), Mask: net.CIDRMask(24, 32)},
+			{IP: net.ParseIP("0.0.0.0"), Mask: net.CIDRMask(0, 32)},
+			{IP: net.ParseIP("fd02::"), Mask: net.CIDRMask(64, 128)},
+			{IP: net.ParseIP("::"), Mask: net.CIDRMask(0, 128)},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add egress: %w", err)
+		}
+
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 0 {
+			return errors.New("ipv4 should be ignored")
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 1 {
+			return errors.New("failed to add ipv6 dst to table 117")
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func testClientCustom(t *testing.T) {
+	t.Parallel()
+
+	cNS, err := ns.GetNS("/run/netns/test-client-custom")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cNS.Close()
+
+	err = cNS.Do(func(ns.NetNS) error {
+		nc := NewNatClient(net.ParseIP("10.1.1.1"), net.ParseIP("fd02::1"), []*net.IPNet{
+			{IP: net.ParseIP("192.168.10.0"), Mask: net.CIDRMask(24, 32)},
+			{IP: net.ParseIP("fd02::"), Mask: net.CIDRMask(16, 128)},
+		})
+		if err := nc.Init(); err != nil {
+			return err
+		}
+
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		dummy := &netlink.Dummy{LinkAttrs: attrs}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("failed to add dummy link: %w", err)
+		}
+		link, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return fmt.Errorf("failed to get dummy1: %w", err)
+		}
+		err = nc.AddEgress(link, []*net.IPNet{
+			{IP: net.ParseIP("10.1.2.0"), Mask: net.CIDRMask(24, 32)},
+			{IP: net.ParseIP("fd03::"), Mask: net.CIDRMask(64, 128)},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add egress: %w", err)
+		}
+
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 0 {
+			return errors.New("should respect custom IPv4 private networks")
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 0 {
+			return errors.New("should respect custom IPv6 private networks")
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/v2/pkg/founat/client_test.go
+++ b/v2/pkg/founat/client_test.go
@@ -171,6 +171,41 @@ func testClientDual(t *testing.T) {
 			return errors.New("failed to add ipv6 dst to table 118")
 		}
 
+		// NATClient can be re-initialized
+		if err := nc.Init(); err != nil {
+			return fmt.Errorf("failed to re-initialize NATClient: %w", err)
+		}
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 0 {
+			return fmt.Errorf("routing table 117 should be cleared for IPv4: %v", routes)
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 118}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 0 {
+			return fmt.Errorf("routing table 118 should be cleared for IPv4: %v", routes)
+		}
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 0 {
+			return fmt.Errorf("routing table 117 should be cleared for IPv6: %v", routes)
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 118}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 0 {
+			return fmt.Errorf("routing table 118 should be cleared for IPv6: %v", routes)
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/v2/pkg/founat/egress.go
+++ b/v2/pkg/founat/egress.go
@@ -1,0 +1,152 @@
+package founat
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	egressTableID    = 118
+	egressProtocolID = 30
+	egressRulePrio   = 2000
+
+	egressDummy = "egress-dummy"
+)
+
+// Egress represents NAT and routing service running on egress Pods.
+// Methods are idempotent; i.e. they can be called multiple times.
+type Egress interface {
+	Init() error
+	AddClient(net.IP, netlink.Link) error
+}
+
+// NewEgress creates an Egress
+func NewEgress(iface string, ipv4, ipv6 net.IP) Egress {
+	if ipv4 != nil && ipv4.To4() == nil {
+		panic("invalid IPv4 address")
+	}
+	if ipv6 != nil && ipv6.To4() != nil {
+		panic("invalid IPv6 address")
+	}
+	return &egress{
+		iface: iface,
+		ipv4:  ipv4,
+		ipv6:  ipv6,
+	}
+}
+
+type egress struct {
+	iface string
+	ipv4  net.IP
+	ipv6  net.IP
+
+	mu sync.Mutex
+}
+
+func (e *egress) newRule(family int) *netlink.Rule {
+	r := netlink.NewRule()
+	r.Family = family
+	r.IifName = e.iface
+	r.Table = egressTableID
+	r.Priority = egressRulePrio
+	return r
+}
+
+func (e *egress) Init() error {
+	// avoid double initialization in case the program restarts
+	_, err := netlink.LinkByName(egressDummy)
+	if err == nil {
+		return nil
+	}
+	if _, ok := err.(netlink.LinkNotFoundError); !ok {
+		return err
+	}
+
+	if e.ipv4 != nil {
+		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if err != nil {
+			return err
+		}
+		ipn := netlink.NewIPNet(e.ipv4)
+		err = ipt.Append("nat", "POSTROUTING", "!", "-s", ipn.String(), "-o", e.iface, "-j", "MASQUERADE")
+		if err != nil {
+			return fmt.Errorf("failed to setup masquerade rule for IPv4: %w", err)
+		}
+
+		rule := e.newRule(netlink.FAMILY_V4)
+		if err := netlink.RuleAdd(rule); err != nil {
+			return fmt.Errorf("netlink: failed to add egress rule for IPv4: %w", err)
+		}
+	}
+	if e.ipv6 != nil {
+		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return err
+		}
+		ipn := netlink.NewIPNet(e.ipv6)
+		err = ipt.Append("nat", "POSTROUTING", "!", "-s", ipn.String(), "-o", e.iface, "-j", "MASQUERADE")
+		if err != nil {
+			return fmt.Errorf("failed to setup masquerade rule for IPv6: %w", err)
+		}
+
+		rule := e.newRule(netlink.FAMILY_V6)
+		if err := netlink.RuleAdd(rule); err != nil {
+			return fmt.Errorf("netlink: failed to add egress rule for IPv6: %w", err)
+		}
+	}
+
+	attrs := netlink.NewLinkAttrs()
+	attrs.Name = egressDummy
+	return netlink.LinkAdd(&netlink.Dummy{LinkAttrs: attrs})
+}
+
+func (e *egress) AddClient(addr net.IP, link netlink.Link) error {
+	// Note:
+	// The following checks are not necessary in fact because,
+	// prior to this point, the support for the IP family is tested
+	// by FouTunnel.AddPeer().  If the test fails, then no `link`
+	// is created and this method will not be called.
+	// Just as a safeguard.
+	if addr.To4() != nil && e.ipv4 == nil {
+		return ErrIPFamilyMismatch
+	}
+	if addr.To4() == nil && e.ipv6 == nil {
+		return ErrIPFamilyMismatch
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	family := netlink.FAMILY_V4
+	if addr.To4() == nil {
+		family = netlink.FAMILY_V6
+	}
+	routes, err := netlink.RouteListFiltered(family, &netlink.Route{Table: egressTableID}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return fmt.Errorf("netlink: failed to list routes in table %d: %w", egressTableID, err)
+	}
+
+	for _, r := range routes {
+		if r.Dst == nil {
+			continue
+		}
+		if r.Dst.IP.Equal(addr) {
+			return nil
+		}
+	}
+
+	err = netlink.RouteAdd(&netlink.Route{
+		Dst:       netlink.NewIPNet(addr),
+		LinkIndex: link.Attrs().Index,
+		Table:     egressTableID,
+		Protocol:  egressProtocolID,
+	})
+	if err != nil {
+		return fmt.Errorf("netlink: failed to add %s to table %d: %w", addr.String(), egressTableID, err)
+	}
+	return nil
+}

--- a/v2/pkg/founat/egress_test.go
+++ b/v2/pkg/founat/egress_test.go
@@ -1,0 +1,318 @@
+package founat
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/vishvananda/netlink"
+)
+
+func TestEgress(t *testing.T) {
+	t.Run("Dual", testEgressDual)
+	t.Run("IPv4", testEgressV4)
+	t.Run("IPv6", testEgressV6)
+}
+
+func testEgressDual(t *testing.T) {
+	t.Parallel()
+
+	eNS, err := ns.GetNS("/run/netns/test-egress-dual")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eNS.Close()
+
+	err = eNS.Do(func(ns.NetNS) error {
+		eg := NewEgress("lo", net.ParseIP("127.0.0.1"), net.ParseIP("::1"))
+		if err := eg.Init(); err != nil {
+			return fmt.Errorf("eg.Init failed: %w", err)
+		}
+
+		// test initialization twice
+		if err := eg.Init(); err != nil {
+			return fmt.Errorf("eg.Init again failed: %w", err)
+		}
+
+		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if err != nil {
+			return err
+		}
+		exist, err := ipt.Exists("nat", "POSTROUTING", "!", "-s", "127.0.0.1/32", "-o", "lo", "-j", "MASQUERADE")
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return errors.New("NAT rule not found for IPv4")
+		}
+
+		ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return err
+		}
+		exist, err = ipt.Exists("nat", "POSTROUTING", "!", "-s", "::1/128", "-o", "lo", "-j", "MASQUERADE")
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return errors.New("NAT rule not found for IPv6")
+		}
+
+		rm, err := ruleMap(netlink.FAMILY_V4)
+		if err != nil {
+			return err
+		}
+		if r, ok := rm[2000]; !ok {
+			return errors.New("no ip rule 2000 for IPv4")
+		} else {
+			if r.Table != 118 {
+				return fmt.Errorf("wrong table for IPv4 rule: %d", r.Table)
+			}
+			if r.IifName != "lo" {
+				return fmt.Errorf("wrong incoming interface for IPv4 rule: %s", r.IifName)
+			}
+		}
+
+		rm, err = ruleMap(netlink.FAMILY_V6)
+		if err != nil {
+			return err
+		}
+		if r, ok := rm[2000]; !ok {
+			return errors.New("no ip rule 2000 for IPv6")
+		} else {
+			if r.Table != 118 {
+				return fmt.Errorf("wrong table for IPv6 rule: %d", r.Table)
+			}
+			if r.IifName != "lo" {
+				return fmt.Errorf("wrong incoming interface for IPv6 rule: %s", r.IifName)
+			}
+		}
+
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: attrs}); err != nil {
+			return err
+		}
+		link, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return err
+		}
+
+		if err := eg.AddClient(net.ParseIP("10.1.2.3"), link); err != nil {
+			return fmt.Errorf("failed to call AddClient with 10.1.2.3: %w", err)
+		}
+		if err := eg.AddClient(net.ParseIP("fd02::1"), link); err != nil {
+			return fmt.Errorf("failed to call AddClient with fd02::1: %w", err)
+		}
+
+		// call again
+		if err := eg.AddClient(net.ParseIP("10.1.2.3"), link); err != nil {
+			return fmt.Errorf("failed to call again AddClient with 10.1.2.3: %w", err)
+		}
+		if err := eg.AddClient(net.ParseIP("fd02::1"), link); err != nil {
+			return fmt.Errorf("failed to call again AddClient with fd02::1: %w", err)
+		}
+
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 118}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 1 {
+			return fmt.Errorf("unexpected routes for IPv4: %v", routes)
+		}
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 118}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 1 {
+			return fmt.Errorf("unexpected routes for IPv6: %v", routes)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func testEgressV4(t *testing.T) {
+	t.Parallel()
+
+	eNS, err := ns.GetNS("/run/netns/test-egress-v4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eNS.Close()
+
+	err = eNS.Do(func(ns.NetNS) error {
+		eg := NewEgress("lo", net.ParseIP("127.0.0.1"), nil)
+		if err := eg.Init(); err != nil {
+			return fmt.Errorf("eg.Init failed: %w", err)
+		}
+
+		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if err != nil {
+			return err
+		}
+		exist, err := ipt.Exists("nat", "POSTROUTING", "!", "-s", "127.0.0.1/32", "-o", "lo", "-j", "MASQUERADE")
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return errors.New("NAT rule not found for IPv4")
+		}
+
+		ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return err
+		}
+		exist, err = ipt.Exists("nat", "POSTROUTING", "!", "-s", "::1/128", "-o", "lo", "-j", "MASQUERADE")
+		if err != nil {
+			return err
+		}
+		if exist {
+			return errors.New("NAT rule found for IPv6")
+		}
+
+		rm, err := ruleMap(netlink.FAMILY_V4)
+		if err != nil {
+			return err
+		}
+		if r, ok := rm[2000]; !ok {
+			return errors.New("no ip rule 2000 for IPv4")
+		} else {
+			if r.Table != 118 {
+				return fmt.Errorf("wrong table for IPv4 rule: %d", r.Table)
+			}
+			if r.IifName != "lo" {
+				return fmt.Errorf("wrong incoming interface for IPv4 rule: %s", r.IifName)
+			}
+		}
+
+		rm, err = ruleMap(netlink.FAMILY_V6)
+		if err != nil {
+			return err
+		}
+		if _, ok := rm[2000]; ok {
+			return errors.New("found ip rule 2000 for IPv6")
+		}
+
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: attrs}); err != nil {
+			return err
+		}
+		link, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return err
+		}
+
+		if err := eg.AddClient(net.ParseIP("10.1.2.3"), link); err != nil {
+			return fmt.Errorf("failed to call AddClient with 10.1.2.3: %w", err)
+		}
+		if err := eg.AddClient(net.ParseIP("fd02::1"), link); err != ErrIPFamilyMismatch {
+			return fmt.Errorf("unexpected error: %T", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func testEgressV6(t *testing.T) {
+	t.Parallel()
+
+	eNS, err := ns.GetNS("/run/netns/test-egress-v6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eNS.Close()
+
+	err = eNS.Do(func(ns.NetNS) error {
+		eg := NewEgress("lo", nil, net.ParseIP("::1"))
+		if err := eg.Init(); err != nil {
+			return fmt.Errorf("eg.Init failed: %w", err)
+		}
+
+		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if err != nil {
+			return err
+		}
+		exist, err := ipt.Exists("nat", "POSTROUTING", "!", "-s", "127.0.0.1/32", "-o", "lo", "-j", "MASQUERADE")
+		if err != nil {
+			return err
+		}
+		if exist {
+			return errors.New("NAT rule found for IPv4")
+		}
+
+		ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return err
+		}
+		exist, err = ipt.Exists("nat", "POSTROUTING", "!", "-s", "::1/128", "-o", "lo", "-j", "MASQUERADE")
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return errors.New("NAT rule not found for IPv6")
+		}
+
+		rm, err := ruleMap(netlink.FAMILY_V4)
+		if err != nil {
+			return err
+		}
+		if _, ok := rm[2000]; ok {
+			return errors.New("found ip rule 2000 for IPv4")
+		}
+
+		rm, err = ruleMap(netlink.FAMILY_V6)
+		if err != nil {
+			return err
+		}
+		if r, ok := rm[2000]; !ok {
+			return errors.New("no ip rule 2000 for IPv6")
+		} else {
+			if r.Table != 118 {
+				return fmt.Errorf("wrong table for IPv6 rule: %d", r.Table)
+			}
+			if r.IifName != "lo" {
+				return fmt.Errorf("wrong incoming interface for IPv6 rule: %s", r.IifName)
+			}
+		}
+
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: attrs}); err != nil {
+			return err
+		}
+		link, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return err
+		}
+
+		if err := eg.AddClient(net.ParseIP("10.1.2.3"), link); err != ErrIPFamilyMismatch {
+			return fmt.Errorf("unexpected error: %T", err)
+		}
+		if err := eg.AddClient(net.ParseIP("fd02::1"), link); err != nil {
+			return fmt.Errorf("failed to call AddClient with fd02::1: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/v2/pkg/founat/errors.go
+++ b/v2/pkg/founat/errors.go
@@ -1,0 +1,7 @@
+package founat
+
+import "errors"
+
+// ErrIPFamilyMismatch is the sentinel error to indicate that FoUTunnel or Egress
+// cannot handle the given address because it is not setup for the address family.
+var ErrIPFamilyMismatch = errors.New("no matching IP family")

--- a/v2/pkg/founat/fou.go
+++ b/v2/pkg/founat/fou.go
@@ -1,0 +1,259 @@
+package founat
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"net"
+	"os/exec"
+	"strconv"
+	"sync"
+
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/containernetworking/plugins/pkg/utils/sysctl"
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/vishvananda/netlink"
+)
+
+// Prefixes for Foo-over-UDP tunnel link names
+const (
+	FoU4LinkPrefix = "fou4_"
+	FoU6LinkPrefix = "fou6_"
+)
+
+const fouDummy = "fou-dummy"
+
+func fouName(addr net.IP) string {
+	if v4 := addr.To4(); v4 != nil {
+		return fmt.Sprintf("%s%x", FoU4LinkPrefix, []byte(v4))
+	}
+
+	hash := sha1.Sum([]byte(addr))
+	return fmt.Sprintf("%s%x", FoU6LinkPrefix, hash[:4])
+}
+
+func modProbe(module string) error {
+	out, err := exec.Command("/sbin/modprobe", module).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("modprobe %s failed with %w: %s", module, err, string(out))
+	}
+	return nil
+}
+
+// FoUTunnel represents the interface for Foo-over-UDP tunnels.
+// Methods are idempotent; i.e. they can be called multiple times.
+type FoUTunnel interface {
+	// Init starts FoU listening socket.
+	Init() error
+
+	// AddPeer setups tunnel devices to the given peer and returns them.
+	// If FoUTunnel does not setup for the IP family of the given address,
+	// this returns ErrIPFamilyMismatch error.
+	AddPeer(net.IP) (netlink.Link, error)
+
+	// DelPeer deletes tunnel for the peer, if any.
+	DelPeer(net.IP) error
+}
+
+// NewFoUTunnel creates a new FoUTunnel.
+// port is the UDP port to receive FoU packets.
+// localIPv4 is the local IPv4 address of the IPIP tunnel.  This can be nil.
+// localIPv6 is the same as localIPv4 for IPv6.
+func NewFoUTunnel(port int, localIPv4, localIPv6 net.IP) FoUTunnel {
+	if localIPv4 != nil && localIPv4.To4() == nil {
+		panic("invalid IPv4 address")
+	}
+	if localIPv6 != nil && localIPv6.To4() != nil {
+		panic("invalid IPv6 address")
+	}
+	return &fouTunnel{
+		port:   port,
+		local4: localIPv4,
+		local6: localIPv6,
+	}
+}
+
+type fouTunnel struct {
+	port   int
+	local4 net.IP
+	local6 net.IP
+
+	mu sync.Mutex
+}
+
+func (t *fouTunnel) Init() error {
+	// avoid double initialization in case the program restarts
+	_, err := netlink.LinkByName(fouDummy)
+	if err == nil {
+		return nil
+	}
+	if _, ok := err.(netlink.LinkNotFoundError); !ok {
+		return err
+	}
+
+	if t.local4 != nil {
+		if err := modProbe("fou"); err != nil {
+			return fmt.Errorf("failed to load fou module: %w", err)
+		}
+		err := netlink.FouAdd(netlink.Fou{
+			Family:    netlink.FAMILY_V4,
+			Protocol:  4, // IPv4 over IPv4 (so-called IPIP)
+			Port:      t.port,
+			EncapType: netlink.FOU_ENCAP_DIRECT,
+		})
+		if err != nil {
+			return fmt.Errorf("netlink: fou add failed: %w", err)
+		}
+		if _, err := sysctl.Sysctl("net.ipv4.conf.default.rp_filter", "0"); err != nil {
+			return fmt.Errorf("setting net.ipv4.conf.default.rp_filter=0 failed: %w", err)
+		}
+		if _, err := sysctl.Sysctl("net.ipv4.conf.all.rp_filter", "0"); err != nil {
+			return fmt.Errorf("setting net.ipv4.conf.all.rp_filter=0 failed: %w", err)
+		}
+		if err := ip.EnableIP4Forward(); err != nil {
+			return fmt.Errorf("failed to enable IPv4 forwarding: %w", err)
+		}
+
+		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if err != nil {
+			return err
+		}
+		// workaround for kube-proxy's double NAT problem
+		rulespec := []string{
+			"-p", "udp", "--dport", strconv.Itoa(t.port), "-j", "CHECKSUM", "--checksum-fill",
+		}
+		if err := ipt.Insert("mangle", "POSTROUTING", 1, rulespec...); err != nil {
+			return fmt.Errorf("failed to setup mangle table: %w", err)
+		}
+	}
+	if t.local6 != nil {
+		if err := modProbe("fou6"); err != nil {
+			return fmt.Errorf("failed to load fou6 module: %w", err)
+		}
+		err := netlink.FouAdd(netlink.Fou{
+			Family:    netlink.FAMILY_V6,
+			Protocol:  41, // IPv6 over IPv6 (so-called SIT)
+			Port:      t.port,
+			EncapType: netlink.FOU_ENCAP_DIRECT,
+		})
+		if err != nil {
+			return fmt.Errorf("netlink: fou add failed: %w", err)
+		}
+		if err := ip.EnableIP6Forward(); err != nil {
+			return fmt.Errorf("failed to enable IPv6 forwarding: %w", err)
+		}
+
+		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return err
+		}
+		// workaround for kube-proxy's double NAT problem
+		rulespec := []string{
+			"-p", "udp", "--dport", strconv.Itoa(t.port), "-j", "CHECKSUM", "--checksum-fill",
+		}
+		if err := ipt.Insert("mangle", "POSTROUTING", 1, rulespec...); err != nil {
+			return fmt.Errorf("failed to setup mangle table: %w", err)
+		}
+
+		// avoid any existing DROP rule by rpfilter extension.
+		// NB: commented as this runs in a Pod network namespace and there should be no rules.
+		// if err := ipt.Insert("raw", "PREROUTING", 1, "-j", "ACCEPT"); err != nil {
+		// 	return err
+		// }
+	}
+
+	attrs := netlink.NewLinkAttrs()
+	attrs.Name = fouDummy
+	return netlink.LinkAdd(&netlink.Dummy{LinkAttrs: attrs})
+}
+
+func (t *fouTunnel) AddPeer(addr net.IP) (netlink.Link, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if v4 := addr.To4(); v4 != nil {
+		return t.addPeer4(v4)
+	}
+	return t.addPeer6(addr)
+}
+
+func (t *fouTunnel) addPeer4(addr net.IP) (netlink.Link, error) {
+	if t.local4 == nil {
+		return nil, ErrIPFamilyMismatch
+	}
+
+	linkName := fouName(addr)
+
+	link, err := netlink.LinkByName(linkName)
+	if err == nil {
+		return link, nil
+	}
+	if _, ok := err.(netlink.LinkNotFoundError); !ok {
+		return nil, fmt.Errorf("netlink: failed to get link: %w", err)
+	}
+
+	attrs := netlink.NewLinkAttrs()
+	attrs.Name = linkName
+	attrs.Flags = net.FlagUp
+	link = &netlink.Iptun{
+		LinkAttrs:  attrs,
+		Ttl:        225,
+		EncapType:  netlink.FOU_ENCAP_DIRECT,
+		EncapDport: uint16(t.port),
+		EncapSport: uint16(t.port),
+		Remote:     addr,
+		Local:      t.local4,
+	}
+	if err := netlink.LinkAdd(link); err != nil {
+		return nil, fmt.Errorf("netlink: failed to add fou link: %w", err)
+	}
+
+	return netlink.LinkByName(linkName)
+}
+
+func (t *fouTunnel) addPeer6(addr net.IP) (netlink.Link, error) {
+	if t.local6 == nil {
+		return nil, ErrIPFamilyMismatch
+	}
+
+	linkName := fouName(addr)
+
+	link, err := netlink.LinkByName(linkName)
+	if err == nil {
+		return link, nil
+	}
+	if _, ok := err.(netlink.LinkNotFoundError); !ok {
+		return nil, fmt.Errorf("netlink: failed to get link: %w", err)
+	}
+
+	attrs := netlink.NewLinkAttrs()
+	attrs.Name = linkName
+	attrs.Flags = net.FlagUp
+	link = &netlink.Ip6tnl{
+		LinkAttrs:  attrs,
+		Ttl:        225,
+		EncapType:  netlink.FOU_ENCAP_DIRECT,
+		EncapDport: uint16(t.port),
+		EncapSport: uint16(t.port),
+		Remote:     addr,
+		Local:      t.local6,
+	}
+	if err := netlink.LinkAdd(link); err != nil {
+		return nil, fmt.Errorf("netlink: failed to add fou6 link: %w", err)
+	}
+
+	return netlink.LinkByName(linkName)
+}
+
+func (t *fouTunnel) DelPeer(addr net.IP) error {
+	linkName := fouName(addr)
+
+	link, err := netlink.LinkByName(linkName)
+	if err == nil {
+		return netlink.LinkDel(link)
+	}
+
+	if _, ok := err.(netlink.LinkNotFoundError); ok {
+		return nil
+	}
+	return err
+}

--- a/v2/pkg/founat/fou_test.go
+++ b/v2/pkg/founat/fou_test.go
@@ -1,0 +1,301 @@
+package founat
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+func TestFoU(t *testing.T) {
+	t.Run("Dual", testFoUDual)
+	t.Run("IPv4", testFoUV4)
+	t.Run("IPv6", testFoUV6)
+}
+
+func testFoUDual(t *testing.T) {
+	t.Parallel()
+
+	fNS, err := ns.GetNS("/run/netns/test-fou-dual")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fNS.Close()
+
+	err = fNS.Do(func(ns.NetNS) error {
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: attrs}); err != nil {
+			return fmt.Errorf("failed to add dummy1: %w", err)
+		}
+		dummy, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return fmt.Errorf("failed to get dummy1: %w", err)
+		}
+		err = netlink.AddrAdd(dummy, &netlink.Addr{
+			IPNet: &net.IPNet{IP: net.ParseIP("10.1.1.0"), Mask: net.CIDRMask(24, 32)},
+		})
+		if err != nil {
+			return fmt.Errorf("netlink: failed to add an IPv4 address: %w", err)
+		}
+		err = netlink.AddrAdd(dummy, &netlink.Addr{
+			IPNet: &net.IPNet{IP: net.ParseIP("fd02::100"), Mask: net.CIDRMask(120, 128)},
+		})
+		if err != nil {
+			return fmt.Errorf("netlink: failed to add an IPv6 address: %w", err)
+		}
+
+		fou := NewFoUTunnel(5555, net.ParseIP("127.0.0.1"), net.ParseIP("::1"))
+		if err := fou.Init(); err != nil {
+			return fmt.Errorf("fou.Init failed: %w", err)
+		}
+
+		// test initialization twice
+		if err := fou.Init(); err != nil {
+			return fmt.Errorf("fou.Init again failed: %w", err)
+		}
+
+		fous, err := netlink.FouList(0)
+		// On GitHub Actions, netlink.FouList fails with ErrAttrBodyTruncated
+		if err != nil && err != netlink.ErrAttrBodyTruncated {
+			return fmt.Errorf("failed to list fou links: %w", err)
+		}
+		if err == nil {
+			if len(fous) != 2 {
+				return fmt.Errorf("unexpected fou list: %+v", fous)
+			}
+			for i, f := range fous {
+				if f.Port != 5555 {
+					return fmt.Errorf("unexpected fous[%d] port number: %d", i, f.Port)
+				}
+			}
+		}
+
+		if link, err := fou.AddPeer(net.ParseIP("10.1.1.1")); err != nil {
+			return fmt.Errorf("failed to call AddPeer with 10.1.1.1: %w", err)
+		} else {
+			iptun, ok := link.(*netlink.Iptun)
+			if !ok {
+				return fmt.Errorf("link is not Iptun: %T", link)
+			}
+			if !iptun.Remote.Equal(net.ParseIP("10.1.1.1")) {
+				return fmt.Errorf("remote is not 10.1.1.1: %s", iptun.Remote.String())
+			}
+			if !iptun.Local.Equal(net.ParseIP("127.0.0.1")) {
+				return fmt.Errorf("local is not 127.0.0.1: %s", iptun.Local.String())
+			}
+			if iptun.EncapDport != 5555 {
+				return fmt.Errorf("iptun.EncapDport is not 5555: %d", iptun.EncapDport)
+			}
+			if iptun.EncapSport != 5555 {
+				return fmt.Errorf("iptun.EncapSport is not 5555: %d", iptun.EncapSport)
+			}
+		}
+
+		if link, err := fou.AddPeer(net.ParseIP("fd02::101")); err != nil {
+			return fmt.Errorf("failed to call AddPeer with fd02::101: %w", err)
+		} else {
+			ip6tnl, ok := link.(*netlink.Ip6tnl)
+			if !ok {
+				return fmt.Errorf("link is not Iptun: %T", link)
+			}
+			if !ip6tnl.Remote.Equal(net.ParseIP("fd02::101")) {
+				return fmt.Errorf("remote is not fd02::101: %s", ip6tnl.Remote.String())
+			}
+			if !ip6tnl.Local.Equal(net.ParseIP("::1")) {
+				return fmt.Errorf("local is not ::1: %s", ip6tnl.Local.String())
+			}
+			if ip6tnl.EncapDport != 5555 {
+				return fmt.Errorf("ip6tnl.EncapDport is not 5555: %d", ip6tnl.EncapDport)
+			}
+			if ip6tnl.EncapSport != 5555 {
+				return fmt.Errorf("ip6tnl.EncapSport is not 5555: %d", ip6tnl.EncapSport)
+			}
+		}
+
+		if err := fou.DelPeer(net.ParseIP("10.1.1.1")); err != nil {
+			return fmt.Errorf("failed to call DelPeer with 10.1.1.1: %w", err)
+		}
+		links, err := netlink.LinkList()
+		if err != nil {
+			return err
+		}
+		for _, l := range links {
+			if strings.HasPrefix(l.Attrs().Name, FoU4LinkPrefix) {
+				return fmt.Errorf("undeleted fou link: %s", l.Attrs().Name)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func testFoUV4(t *testing.T) {
+	t.Parallel()
+
+	fNS, err := ns.GetNS("/run/netns/test-fou-v4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fNS.Close()
+
+	err = fNS.Do(func(ns.NetNS) error {
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: attrs}); err != nil {
+			return err
+		}
+		dummy, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return err
+		}
+		err = netlink.AddrAdd(dummy, &netlink.Addr{
+			IPNet: &net.IPNet{IP: net.ParseIP("10.1.1.0"), Mask: net.CIDRMask(24, 32)},
+		})
+		if err != nil {
+			return err
+		}
+
+		fou := NewFoUTunnel(5555, net.ParseIP("127.0.0.1"), nil)
+		if err := fou.Init(); err != nil {
+			return fmt.Errorf("fou.Init failed: %w", err)
+		}
+
+		fous, err := netlink.FouList(0)
+		// On GitHub Actions, netlink.FouList fails with ErrAttrBodyTruncated
+		if err != nil && err != netlink.ErrAttrBodyTruncated {
+			return fmt.Errorf("failed to list fou links: %w", err)
+		}
+		if err == nil {
+			if len(fous) != 1 {
+				return fmt.Errorf("unexpected fou list: %+v", fous)
+			}
+			for i, f := range fous {
+				if f.Port != 5555 {
+					return fmt.Errorf("unexpected fous[%d] port number: %d", i, f.Port)
+				}
+			}
+		}
+
+		if link, err := fou.AddPeer(net.ParseIP("10.1.1.1")); err != nil {
+			return fmt.Errorf("failed to call AddPeer with 10.1.1.1: %w", err)
+		} else {
+			iptun, ok := link.(*netlink.Iptun)
+			if !ok {
+				return fmt.Errorf("link is not Iptun: %T", link)
+			}
+			if !iptun.Remote.Equal(net.ParseIP("10.1.1.1")) {
+				return fmt.Errorf("remote is not 10.1.1.1: %s", iptun.Remote.String())
+			}
+			if !iptun.Local.Equal(net.ParseIP("127.0.0.1")) {
+				return fmt.Errorf("local is not 127.0.0.1: %s", iptun.Local.String())
+			}
+			if iptun.EncapDport != 5555 {
+				return fmt.Errorf("iptun.EncapDport is not 5555: %d", iptun.EncapDport)
+			}
+			if iptun.EncapSport != 5555 {
+				return fmt.Errorf("iptun.EncapSport is not 5555: %d", iptun.EncapSport)
+			}
+		}
+
+		if _, err := fou.AddPeer(net.ParseIP("fd02::101")); err != ErrIPFamilyMismatch {
+			return fmt.Errorf("error is not ErrIPFamilyMismatch: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func testFoUV6(t *testing.T) {
+	t.Parallel()
+
+	fNS, err := ns.GetNS("/run/netns/test-fou-v6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fNS.Close()
+
+	err = fNS.Do(func(ns.NetNS) error {
+		attrs := netlink.NewLinkAttrs()
+		attrs.Name = "dummy1"
+		attrs.Flags = net.FlagUp
+		if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: attrs}); err != nil {
+			return err
+		}
+		dummy, err := netlink.LinkByName("dummy1")
+		if err != nil {
+			return err
+		}
+		err = netlink.AddrAdd(dummy, &netlink.Addr{
+			IPNet: &net.IPNet{IP: net.ParseIP("fd02::100"), Mask: net.CIDRMask(120, 128)},
+		})
+		if err != nil {
+			return err
+		}
+
+		fou := NewFoUTunnel(5555, nil, net.ParseIP("::1"))
+		if err := fou.Init(); err != nil {
+			return fmt.Errorf("fou.Init failed: %w", err)
+		}
+
+		fous, err := netlink.FouList(0)
+		// On GitHub Actions, netlink.FouList fails with ErrAttrBodyTruncated
+		if err != nil && err != netlink.ErrAttrBodyTruncated {
+			return fmt.Errorf("failed to list fou links: %w", err)
+		}
+		if err == nil {
+			if len(fous) != 1 {
+				return fmt.Errorf("unexpected fou list: %+v", fous)
+			}
+			for i, f := range fous {
+				if f.Port != 5555 {
+					return fmt.Errorf("unexpected fous[%d] port number: %d", i, f.Port)
+				}
+			}
+		}
+
+		if _, err := fou.AddPeer(net.ParseIP("10.1.1.1")); err != ErrIPFamilyMismatch {
+			return fmt.Errorf("error is not ErrIPFamilyMismatch: %w", err)
+		}
+
+		if link, err := fou.AddPeer(net.ParseIP("fd02::101")); err != nil {
+			return fmt.Errorf("failed to call AddPeer with fd02::101: %w", err)
+		} else {
+			ip6tnl, ok := link.(*netlink.Ip6tnl)
+			if !ok {
+				return fmt.Errorf("link is not Iptun: %T", link)
+			}
+			if !ip6tnl.Remote.Equal(net.ParseIP("fd02::101")) {
+				return fmt.Errorf("remote is not fd02::101: %s", ip6tnl.Remote.String())
+			}
+			if !ip6tnl.Local.Equal(net.ParseIP("::1")) {
+				return fmt.Errorf("local is not ::1: %s", ip6tnl.Local.String())
+			}
+			if ip6tnl.EncapDport != 5555 {
+				return fmt.Errorf("ip6tnl.EncapDport is not 5555: %d", ip6tnl.EncapDport)
+			}
+			if ip6tnl.EncapSport != 5555 {
+				return fmt.Errorf("ip6tnl.EncapSport is not 5555: %d", ip6tnl.EncapSport)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/v2/pkg/founat/nat_test.go
+++ b/v2/pkg/founat/nat_test.go
@@ -1,0 +1,114 @@
+package founat
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+)
+
+func TestNAT(t *testing.T) {
+	t.Parallel()
+	cNS := getNS(nsClient)
+	defer cNS.Close()
+	eNS := getNS(nsEgress)
+	defer eNS.Close()
+	targetNS := getNS(nsTarget)
+	defer targetNS.Close()
+
+	err := cNS.Do(func(ns.NetNS) error {
+		ft := NewFoUTunnel(5555, net.ParseIP("10.1.1.2"), net.ParseIP("fd01::102"))
+		if err := ft.Init(); err != nil {
+			return fmt.Errorf("ft.Init on client failed: %w", err)
+		}
+
+		nc := NewNatClient(net.ParseIP("10.1.1.2"), net.ParseIP("fd01::102"), nil)
+		if err := nc.Init(); err != nil {
+			return fmt.Errorf("nc.Init failed: %w", err)
+		}
+
+		link4, err := ft.AddPeer(net.ParseIP("10.1.2.2"))
+		if err != nil {
+			return fmt.Errorf("ft.AddPeer failed for 10.1.2.2: %w", err)
+		}
+		link6, err := ft.AddPeer(net.ParseIP("fd01::202"))
+		if err != nil {
+			return fmt.Errorf("ft.AddPeer failed for fd01::202: %w", err)
+		}
+
+		err = nc.AddEgress(link4, []*net.IPNet{{IP: net.ParseIP("10.1.3.0"), Mask: net.CIDRMask(24, 32)}})
+		if err != nil {
+			return fmt.Errorf("nc.AddEgress failed for 10.1.3.0/24: %w", err)
+		}
+		err = nc.AddEgress(link6, []*net.IPNet{{IP: net.ParseIP("fd01::300"), Mask: net.CIDRMask(120, 128)}})
+		if err != nil {
+			return fmt.Errorf("nc.AddEgress failed for fd01::300/120: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = eNS.Do(func(ns.NetNS) error {
+		ft := NewFoUTunnel(5555, net.ParseIP("10.1.2.2"), net.ParseIP("fd01::202"))
+		if err := ft.Init(); err != nil {
+			return fmt.Errorf("ft.Init on egress failed: %w", err)
+		}
+
+		egress := NewEgress("eth1", net.ParseIP("10.1.2.2"), net.ParseIP("fd01::202"))
+		if err := egress.Init(); err != nil {
+			return fmt.Errorf("egress.Init failed: %w", err)
+		}
+
+		link4, err := ft.AddPeer(net.ParseIP("10.1.1.2"))
+		if err != nil {
+			return fmt.Errorf("ft.AddPeer failed for 10.1.1.2: %w", err)
+		}
+		link6, err := ft.AddPeer(net.ParseIP("fd01::102"))
+		if err != nil {
+			return fmt.Errorf("ft.AddPeer failed for fd01::102: %w", err)
+		}
+
+		if err := egress.AddClient(net.ParseIP("10.1.1.2"), link4); err != nil {
+			return fmt.Errorf("egress.AddClient failed for 10.1.1.2: %w", err)
+		}
+		if err := egress.AddClient(net.ParseIP("fd01::102"), link6); err != nil {
+			return fmt.Errorf("egress.AddClient failed for 10.1.1.2: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go targetNS.Do(func(_ ns.NetNS) error {
+		s := &http.Server{}
+		t.Log("httpd running in the target network namespace")
+		s.ListenAndServe()
+		return nil
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	err = cNS.Do(func(ns.NetNS) error {
+		out, err := exec.Command("curl", "http://10.1.3.1").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("curl over fou IPv4 failed: %s, %w", string(out), err)
+		}
+		out, err = exec.Command("curl", "http://[fd01::301]").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("curl over fou IPv6 failed: %s, %w", string(out), err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/v2/pkg/founat/setup_test.go
+++ b/v2/pkg/founat/setup_test.go
@@ -1,0 +1,88 @@
+package founat
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getuid() != 0 {
+		os.Exit(0)
+	}
+
+	setup()
+	os.Exit(m.Run())
+}
+
+const (
+	nsClient = "nat-client"
+	nsRouter = "nat-router"
+	nsEgress = "nat-egress"
+	nsTarget = "nat-target"
+)
+
+func getNS(name string) ns.NetNS {
+	a, err := ns.GetNS(filepath.Join("/run/netns", name))
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+func runIP(args ...string) {
+	out, err := exec.Command("ip", args...).CombinedOutput()
+	if err != nil {
+		panic(fmt.Sprintf("%s: %v", string(out), err))
+	}
+}
+
+func netnsExec(nsName string, args ...string) {
+	nargs := append([]string{"netns", "exec", nsName}, args...)
+	runIP(nargs...)
+}
+
+func setup() {
+	// setup network as follows:
+	// client eth0 <-> eth0 router eth1 <-> eth0 egress eth1 <-> eth0 target
+	runIP("link", "add", "veth-coil", "type", "veth", "peer", "name", "veth-coil2")
+	runIP("link", "set", "veth-coil", "netns", nsClient, "name", "eth0", "up")
+	runIP("link", "set", "veth-coil2", "netns", nsRouter, "name", "eth0", "up")
+	runIP("link", "add", "veth-coil", "type", "veth", "peer", "name", "veth-coil2")
+	runIP("link", "set", "veth-coil", "netns", nsRouter, "name", "eth1", "up")
+	runIP("link", "set", "veth-coil2", "netns", nsEgress, "name", "eth0", "up")
+	runIP("link", "add", "veth-coil", "type", "veth", "peer", "name", "veth-coil2")
+	runIP("link", "set", "veth-coil", "netns", nsEgress, "name", "eth1", "up")
+	runIP("link", "set", "veth-coil2", "netns", nsTarget, "name", "eth0", "up")
+
+	// assign IP addresses
+	// 10.1.1.0/24,fd01::100/120 for client-router
+	// 10.1.2.0/24,fd01::200/120 for router-egress
+	// 10.1.3.0/24,fd01::300/120 for egress-target
+	netnsExec(nsClient, "ip", "a", "add", "10.1.1.2/24", "dev", "eth0")
+	netnsExec(nsClient, "ip", "a", "add", "fd01::102/120", "dev", "eth0", "nodad")
+	netnsExec(nsRouter, "ip", "a", "add", "10.1.1.1/24", "dev", "eth0")
+	netnsExec(nsRouter, "ip", "a", "add", "fd01::101/120", "dev", "eth0", "nodad")
+	netnsExec(nsRouter, "ip", "a", "add", "10.1.2.1/24", "dev", "eth1")
+	netnsExec(nsRouter, "ip", "a", "add", "fd01::201/120", "dev", "eth1", "nodad")
+	netnsExec(nsEgress, "ip", "a", "add", "10.1.2.2/24", "dev", "eth0")
+	netnsExec(nsEgress, "ip", "a", "add", "fd01::202/120", "dev", "eth0", "nodad")
+	netnsExec(nsEgress, "ip", "a", "add", "10.1.3.2/24", "dev", "eth1")
+	netnsExec(nsEgress, "ip", "a", "add", "fd01::302/120", "dev", "eth1", "nodad")
+	netnsExec(nsTarget, "ip", "a", "add", "10.1.3.1/24", "dev", "eth0")
+	netnsExec(nsTarget, "ip", "a", "add", "fd01::301/120", "dev", "eth0", "nodad")
+
+	// setup routing
+	netnsExec(nsRouter, "sysctl", "-w", "net.ipv4.ip_forward=1")
+	netnsExec(nsRouter, "sysctl", "-w", "net.ipv6.conf.all.forwarding=1")
+	netnsExec(nsClient, "ip", "route", "add", "default", "via", "10.1.1.1")
+	netnsExec(nsClient, "ip", "-6", "route", "add", "default", "via", "fd01::101")
+	netnsExec(nsEgress, "ip", "route", "add", "default", "via", "10.1.2.1")
+	netnsExec(nsEgress, "ip", "-6", "route", "add", "default", "via", "fd01::201")
+	netnsExec(nsClient, "ping", "-4", "-c", "1", "10.1.2.2")
+	netnsExec(nsClient, "ping", "-6", "-c", "1", "fd01::202")
+}

--- a/v2/pkg/nodenet/pod_test.go
+++ b/v2/pkg/nodenet/pod_test.go
@@ -19,9 +19,6 @@ func TestPodNetwork(t *testing.T) {
 	if os.Getuid() != 0 {
 		t.Skip("run as root")
 	}
-	if os.Getenv("CIRCLECI") == "true" {
-		t.Skip("could not run on CircleCI")
-	}
 
 	pn := NewPodNetwork(30, false, ctrl.Log.WithName("pod-network"))
 	if err := pn.Init(); err != nil {
@@ -81,6 +78,10 @@ func TestPodNetwork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		exec.Command("ip", "link", "del", "foo").Run()
+	}()
+
 	err = exec.Command("ip", "link", "set", "foo", "up").Run()
 	if err != nil {
 		t.Fatal(err)
@@ -263,11 +264,5 @@ func TestPodNetwork(t *testing.T) {
 	err = pn.Destroy(podConf2.ContainerId, podConf2.IFace)
 	if err != nil {
 		t.Error(err)
-	}
-
-	// some cleanup
-	err = exec.Command("ip", "link", "del", "foo").Run()
-	if err != nil {
-		t.Fatal(err)
 	}
 }

--- a/v2/pkg/nodenet/route_exporter.go
+++ b/v2/pkg/nodenet/route_exporter.go
@@ -14,6 +14,7 @@ type RouteExporter interface {
 	Sync([]*net.IPNet) error
 }
 
+// NewRouteExporter creates a new RouteExporter
 func NewRouteExporter(tableId, protocolId int, log logr.Logger) RouteExporter {
 	return &routeExporter{
 		tableId:    tableId,

--- a/v2/pkg/nodenet/route_exporter_test.go
+++ b/v2/pkg/nodenet/route_exporter_test.go
@@ -42,9 +42,6 @@ func TestRouteExporter(t *testing.T) {
 	if os.Getuid() != 0 {
 		t.Skip("need root privilege")
 	}
-	if os.Getenv("CIRCLECI") == "true" {
-		t.Skip("could not run on CircleCI")
-	}
 
 	_, n1, _ := net.ParseCIDR("10.2.0.0/27")
 	_, n2, _ := net.ParseCIDR("10.3.0.0/31")

--- a/v2/pkg/nodenet/route_syncer_test.go
+++ b/v2/pkg/nodenet/route_syncer_test.go
@@ -95,9 +95,6 @@ func TestRouteSyncer(t *testing.T) {
 	if os.Getuid() != 0 {
 		t.Skip("need root privilege")
 	}
-	if os.Getenv("CIRCLECI") == "true" {
-		t.Skip("could not run on CircleCI")
-	}
 
 	setupFake(t)
 


### PR DESCRIPTION
This PR adds a set of structs that implement NAT client and server as a whole.

NAT client and server communicate over Foo-over-UDP tunnel.
The implementation supports both IPv4 and IPv6.

Package: `pkg/founat`
Structs:
- `FoUTunnel`: receive FoU UDP packets and create tunnel devices
- `NATClient`: registers egress networks with the routing table
- `Egress`: configure NAT rules