### PR TITLE
coild: enable foo-over-udp NAT feature

### DIFF
--- a/docs/cmd-coild.md
+++ b/docs/cmd-coild.md
@@ -43,6 +43,7 @@ Calico needs to be configured to set [`FELIX_INTERFACEPREFIX`](https://github.co
 ```
 Flags:
       --compat-calico         make veth name compatible with Calico
+      --egress-port int       UDP port number for egress NAT (default 5555)
       --health-addr string    bind address of health/readiness probes (default ":9385")
   -h, --help                  help for coild
       --metrics-addr string   bind address of metrics endpoint (default ":9384")

--- a/v2/cmd/coild/sub/root.go
+++ b/v2/cmd/coild/sub/root.go
@@ -16,6 +16,7 @@ var config struct {
 	protocolId   int
 	socketPath   string
 	compatCalico bool
+	egressPort   int
 }
 
 var rootCmd = &cobra.Command{
@@ -49,4 +50,5 @@ func init() {
 	pf.IntVar(&config.protocolId, "protocol-id", 30, "route author ID")
 	pf.StringVar(&config.socketPath, "socket", constants.DefaultSocketPath, "UNIX domain socket path")
 	pf.BoolVar(&config.compatCalico, "compat-calico", false, "make veth name compatible with Calico")
+	pf.IntVar(&config.egressPort, "egress-port", 5555, "UDP port number for egress NAT")
 }

--- a/v2/cmd/coild/sub/run.go
+++ b/v2/cmd/coild/sub/run.go
@@ -102,7 +102,7 @@ func subMain() error {
 	if err != nil {
 		return err
 	}
-	server := runners.NewCoildServer(l, mgr, nodeIPAM, podNet, grpcLogger)
+	server := runners.NewCoildServer(l, mgr, nodeIPAM, podNet, runners.NewNATSetup(config.egressPort), grpcLogger)
 	if err := mgr.Add(server); err != nil {
 		return err
 	}

--- a/v2/config/rbac/coild_role.yaml
+++ b/v2/config/rbac/coild_role.yaml
@@ -10,6 +10,7 @@ rules:
   - ""
   resources:
   - namespaces
+  - services
   verbs:
   - get
   - list
@@ -52,3 +53,11 @@ rules:
   - blockrequests/status
   verbs:
   - get
+- apiGroups:
+  - coil.cybozu.com
+  resources:
+  - egresses
+  verbs:
+  - get
+  - list
+  - watch

--- a/v2/controllers/pod_watcher.go
+++ b/v2/controllers/pod_watcher.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strings"
 	"sync"
@@ -131,6 +132,10 @@ OUTER:
 		}
 
 		link, err := r.ft.AddPeer(ip)
+		if errors.Is(err, founat.ErrIPFamilyMismatch) {
+			r.log.Info("skipping unsupported pod IP", "pod", pod.Namespace+"/"+pod.Name, "ip", ip.String())
+			continue
+		}
 		if err != nil {
 			return err
 		}

--- a/v2/pkg/nodenet/pod_test.go
+++ b/v2/pkg/nodenet/pod_test.go
@@ -32,9 +32,21 @@ func TestPodNetwork(t *testing.T) {
 		IPv4:        net.ParseIP("10.1.2.3"),
 		IPv6:        net.ParseIP("fd02::1"),
 	}
-	result, err := pn.Setup(nsPath("pod1"), "pod1", "ns1", podConf1)
+	var givenIPv4, givenIPv6 net.IP
+	result, err := pn.Setup(nsPath("pod1"), "pod1", "ns1", podConf1, func(ipv4, ipv6 net.IP) error {
+		givenIPv4 = ipv4
+		givenIPv6 = ipv6
+		return nil
+	})
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if !givenIPv4.Equal(net.ParseIP("10.1.2.3")) {
+		t.Error("hook could not catch IPv4", givenIPv4)
+	}
+	if !givenIPv6.Equal(net.ParseIP("fd02::1")) {
+		t.Error("hook could not catch IPv6", givenIPv6)
 	}
 
 	if len(result.Interfaces) != 2 {
@@ -141,7 +153,7 @@ func TestPodNetwork(t *testing.T) {
 		IFace:       "eth0",
 		IPv4:        net.ParseIP("10.1.2.4"),
 	}
-	result, err = pn.Setup(nsPath("pod2"), "pod2", "ns1", podConf2)
+	result, err = pn.Setup(nsPath("pod2"), "pod2", "ns1", podConf2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +207,7 @@ func TestPodNetwork(t *testing.T) {
 		IFace:       "eth0",
 		IPv6:        net.ParseIP("fd02::3"),
 	}
-	result, err = pn.Setup(nsPath("pod3"), "pod3", "ns1", podConf3)
+	result, err = pn.Setup(nsPath("pod3"), "pod3", "ns1", podConf3, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds support for NAT using foo-over-udp to coild.

The test does not cover the implementation very well.
The functionality will be tested in e2e tests in another PR.