### PR TITLE
End-to-end test for Egress NAT

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
           sudo cp daemon.json /etc/docker/daemon.json
           sudo systemctl restart docker.service
           sleep 10
-          echo "::set-env name=TEST_IPV6::true"
+          echo TEST_IPV6=true >> $GITHUB_ENV
       - run: make start IMAGE=${{ matrix.kindest-node }}
         working-directory: v2/e2e
       - run: make install-coil

--- a/docs/cmd-coil-egress.md
+++ b/docs/cmd-coil-egress.md
@@ -9,11 +9,11 @@ It watches client Pods and creates or deletes Foo-over-UDP tunnels.
 
 `coil-egress` references the following environment variables:
 
-| Name                 | Required | Description                                  |
-| -------------------- | -------- | -------------------------------------------- |
-| `COIL_POD_ADDRESSES` | YES      | `status.podIPs` field value of the Pod.      |
-| `COIL_POD_NAMESPACE` | YES      | `metadata.namespace` field value of the Pod. |
-| `COIL_POD_NAME`      | YES      | `metadata.name` field value of the Pod.      |
+| Name                 | Required | Description                                            |
+| -------------------- | -------- | ------------------------------------------------------ |
+| `COIL_POD_ADDRESSES` | YES      | `status.podIPs` field value of the Pod.                |
+| `COIL_POD_NAMESPACE` | YES      | `metadata.namespace` field value of the parent Egress. |
+| `COIL_EGRESS_NAME`   | YES      | `metadata.name` field value of the parent Egress.      |
 
 ## Command-line flags
 

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -1,6 +1,12 @@
-FROM scratch
+FROM quay.io/cybozu/ubuntu:18.04
 
 # https://docs.github.com/en/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
 LABEL org.opencontainers.image.source https://github.com/cybozu-go/coil
 
-COPY /work /
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends netbase kmod iptables \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY /work /usr/local/coil
+
+ENV PATH /usr/local/coil:$PATH

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -148,9 +148,7 @@ pkg/cnirpc/cni_grpc.pb.go: pkg/cnirpc/cni.proto
 .PHONY: image
 image:
 	-rm -rf work
-	mkdir -p work/var
-	ln -s /run work/var/run
-	CGO_ENABLED=0 GOBIN=$(PWD)/work go install -ldflags="-s -w" ./cmd/coil*
+	GOBIN=$(PWD)/work go install -ldflags="-s -w" ./cmd/coil*
 	cp ../LICENSE work
 	docker build --no-cache -t coil:dev .
 	rm -rf work

--- a/v2/cmd/coil-egress/sub/run.go
+++ b/v2/cmd/coil-egress/sub/run.go
@@ -30,9 +30,9 @@ func subMain() error {
 		return errors.New(constants.EnvPodNamespace + " environment variable must be set")
 	}
 
-	myName := os.Getenv(constants.EnvPodName)
+	myName := os.Getenv(constants.EnvEgressName)
 	if myName == "" {
-		return errors.New(constants.EnvPodName + " environment variable must be set")
+		return errors.New(constants.EnvEgressName + " environment variable must be set")
 	}
 
 	myAddresses := strings.Split(os.Getenv(constants.EnvAddresses), ",")

--- a/v2/cmd/coil-installer/sub/root.go
+++ b/v2/cmd/coil-installer/sub/root.go
@@ -14,7 +14,7 @@ const (
 	defaultCniConfName = "10-coil.conflist"
 	defaultCniEtcDir   = "/host/etc/cni/net.d"
 	defaultCniBinDir   = "/host/opt/cni/bin"
-	defaultCoilPath    = "/coil"
+	defaultCoilPath    = "/usr/local/coil/coil"
 )
 
 var rootCmd = &cobra.Command{

--- a/v2/config/default/pod_security_policy.yaml
+++ b/v2/config/default/pod_security_policy.yaml
@@ -49,6 +49,8 @@ spec:
   allowedHostPaths:
   - pathPrefix: "/run"
     readOnly: false
+  - pathPrefix: "/lib/modules"
+    readOnly: true
   - pathPrefix: "/opt/cni/bin"
     readOnly: false
   - pathPrefix: "/etc/cni/net.d"
@@ -105,6 +107,10 @@ spec:
     - 'emptyDir'
     - 'secret'
     - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+  - pathPrefix: "/lib/modules"
+    readOnly: true
   hostNetwork: false
   seLinux:
     rule: 'RunAsAny'

--- a/v2/config/default/pod_security_policy.yaml
+++ b/v2/config/default/pod_security_policy.yaml
@@ -99,7 +99,7 @@ kind: PodSecurityPolicy
 metadata:
   name: coil-egress
 spec:
-  privileged: false
+  privileged: true
   allowPrivilegeEscalation: false
   allowedCapabilities: ["NET_ADMIN"]
   volumes:

--- a/v2/config/pod/coil-controller.yaml
+++ b/v2/config/pod/coil-controller.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: coil-controller
         image: coil:dev
-        command: ["/coil-controller"]
+        command: ["coil-controller"]
         env:
         - name: "COIL_POD_NAMESPACE"
           valueFrom:

--- a/v2/config/pod/coil-router.yaml
+++ b/v2/config/pod/coil-router.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: coil-router
         image: coil:dev
-        command: ["/coil-router"]
+        command: ["coil-router"]
         env:
         - name: COIL_NODE_NAME
           valueFrom:

--- a/v2/config/pod/coild.yaml
+++ b/v2/config/pod/coild.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: coild
         image: coil:dev
-        command: ["/coild"]
+        command: ["coild"]
         env:
         - name: COIL_NODE_NAME
           valueFrom:
@@ -60,10 +60,13 @@ spec:
         - mountPath: /run
           name: run
           mountPropagation: HostToContainer  # to see bind mount netns file under /run/netns
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
       initContainers:
       - name: coil-installer
         image: coil:dev
-        command: ["/coil-installer"]
+        command: ["coil-installer"]
         env:
         - name: CNI_NETCONF
           valueFrom:
@@ -81,6 +84,9 @@ spec:
       - name: run
         hostPath:
           path: /run
+      - name: modules
+        hostPath:
+          path: /lib/modules
       - name: cni-bin-dir
         hostPath:
           path: /opt/cni/bin

--- a/v2/config/rbac/coil-controller_role.yaml
+++ b/v2/config/rbac/coil-controller_role.yaml
@@ -19,6 +19,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/v2/controllers/egress_controller.go
+++ b/v2/controllers/egress_controller.go
@@ -32,6 +32,9 @@ type EgressReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services;serviceaccounts,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch
 
+// coil-controller needs to have access to Pods to grant egress service accounts the same privilege.
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
 // Reconcile implements Reconciler interface.
 // https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.1/pkg/reconcile?tab=doc#Reconciler
 func (r *EgressReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/v2/controllers/egress_controller.go
+++ b/v2/controllers/egress_controller.go
@@ -191,7 +191,9 @@ func (r *EgressReconciler) reconcilePodTemplate(eg *coilv2.Egress, depl *appsv1.
 		Name:      "modules",
 		ReadOnly:  true,
 	})
+	privileged := true
 	egressContainer.SecurityContext = &corev1.SecurityContext{
+		Privileged:   &privileged,
 		Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_ADMIN"}},
 	}
 	if egressContainer.Resources.Requests == nil {

--- a/v2/controllers/egress_controller.go
+++ b/v2/controllers/egress_controller.go
@@ -130,6 +130,14 @@ func (r *EgressReconciler) reconcilePodTemplate(eg *coilv2.Egress, depl *appsv1.
 	}
 
 	podSpec.ServiceAccountName = constants.SAEgress
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: "modules",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/lib/modules",
+			},
+		},
+	})
 
 	var egressContainer *corev1.Container
 	for i := range podSpec.Containers {
@@ -175,6 +183,11 @@ func (r *EgressReconciler) reconcilePodTemplate(eg *coilv2.Egress, depl *appsv1.
 			},
 		},
 	)
+	egressContainer.VolumeMounts = append(egressContainer.VolumeMounts, corev1.VolumeMount{
+		MountPath: "/lib/modules",
+		Name:      "modules",
+		ReadOnly:  true,
+	})
 	egressContainer.SecurityContext = &corev1.SecurityContext{
 		Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_ADMIN"}},
 	}

--- a/v2/controllers/egress_controller_test.go
+++ b/v2/controllers/egress_controller_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Egress reconciler", func() {
 		Expect(depl.Spec.Template.Labels).To(HaveKeyWithValue(constants.LabelAppComponent, "egress"))
 		Expect(depl.Spec.Template.Labels).To(HaveKeyWithValue(constants.LabelAppInstance, eg.Name))
 		Expect(depl.Spec.Template.Spec.ServiceAccountName).To(Equal("coil-egress"))
+		Expect(depl.Spec.Template.Spec.Volumes).To(HaveLen(1))
 
 		var egressContainer *corev1.Container
 		for i := range depl.Spec.Template.Spec.Containers {
@@ -116,6 +117,7 @@ var _ = Describe("Egress reconciler", func() {
 		Expect(egressContainer.Image).To(Equal("coil:dev"))
 		Expect(egressContainer.Command).To(Equal([]string{"coil-egress"}))
 		Expect(egressContainer.Env).To(HaveLen(3))
+		Expect(egressContainer.VolumeMounts).To(HaveLen(1))
 		Expect(egressContainer.Resources.Requests).To(HaveKey(corev1.ResourceCPU))
 		Expect(egressContainer.Resources.Requests).To(HaveKey(corev1.ResourceMemory))
 		Expect(egressContainer.Ports).To(HaveLen(2))
@@ -194,6 +196,11 @@ var _ = Describe("Egress reconciler", func() {
 					Containers: []corev1.Container{
 						{Name: "sidecar", Image: "nginx"},
 					},
+					Volumes: []corev1.Volume{
+						{Name: "dummy", VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{Path: "/dummy"},
+						}},
+					},
 				},
 			}
 			return k8sClient.Update(ctx, eg)
@@ -220,6 +227,7 @@ var _ = Describe("Egress reconciler", func() {
 		Expect(depl.Spec.Template.Labels).To(HaveKeyWithValue("foo", "bar"))
 		Expect(depl.Spec.Template.Labels).To(HaveKeyWithValue(constants.LabelAppName, "coil"))
 		Expect(depl.Spec.Template.Spec.SchedulerName).To(Equal("hoge-scheduler"))
+		Expect(depl.Spec.Template.Spec.Volumes).To(HaveLen(2))
 		var sidecar, egressContainer *corev1.Container
 		for i := range depl.Spec.Template.Spec.Containers {
 			if depl.Spec.Template.Spec.Containers[i].Name == "egress" {

--- a/v2/e2e/Makefile
+++ b/v2/e2e/Makefile
@@ -34,6 +34,9 @@ install-coil:
 
 .PHONY: test
 test:
+	go build -o echotest ./echo-server
+	docker cp echotest coil-control-plane:/usr/local/bin
+	rm echotest
 	go test -count 1 -v . -args -ginkgo.progress -ginkgo.v
 
 .PHONY: setup

--- a/v2/e2e/README.md
+++ b/v2/e2e/README.md
@@ -10,6 +10,7 @@ end-to-end (e2e) tests for Coil.
   - [`coil-controller`](#coil-controller)
   - [`coild`](#coild)
   - [`coil-router`](#coil-router)
+  - [`coil-egress`](#coil-egress)
 - [How to test](#how-to-test)
 - [Implementation](#implementation)
 
@@ -21,6 +22,7 @@ integration tests.  The exceptions are:
 - YAML manifests
 - `main` function of each program
 - inter-node communication
+- Egress NAT over Kubernetes `Service`
 
 Therefore, it is enough to cover these functions in e2e tests.
 
@@ -51,6 +53,7 @@ What the `main` function implements are:
 - gRPC server for `coil`
 - Route exporter
 - Persisting IPAM status between restarts
+- Setup egress NAT clients
 
 ### `coil-router`
 
@@ -59,6 +62,10 @@ What the `main` function implements are:
 - Health probe server
 - Metrics server
 - Routing table setup for inter-node communication
+
+### `coil-egress`
+
+- Watcher for client pods
 
 ## How to test
 
@@ -77,6 +84,14 @@ orphaned AddressBlock manually.
 
 Persisting IPAM status in `coild` can be tested by restarting `coild` Pods
 and examine the allocation status.
+
+Egress NAT feature can be tested by running Egress pods on a specific
+node and assigning a fake global IP address such as `9.9.9.9/32` to a dummy
+interface of the node.  That fake address is reachable only from the pods
+running on the node because such pods route all the packets to the node.
+
+Then, run a NAT client pod on another node.  If the NAT client can reach
+the fake IP address, we can prove that the Egress NAT feature is working.
 
 Other functions can be tested straightforwardly.
 

--- a/v2/e2e/coil_test.go
+++ b/v2/e2e/coil_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
 	. "github.com/onsi/ginkgo"
@@ -239,5 +240,84 @@ var _ = Describe("Coil", func() {
 			}
 			return nil
 		}).Should(Succeed())
+	})
+
+	It("should be able to run Egress pods", func() {
+		By("creating internet namespace")
+		kubectlSafe(nil, "create", "ns", "internet")
+
+		By("defining Egress in the internet namespace")
+		kubectlSafe(nil, "apply", "-f", "manifests/egress.yaml")
+
+		By("checking pod deployments")
+		Eventually(func() int {
+			depl := &appsv1.Deployment{}
+			err := getResource("internet", "deployments", "egress", "", depl)
+			if err != nil {
+				return 0
+			}
+			return int(depl.Status.ReadyReplicas)
+		}).Should(Equal(2))
+	})
+
+	It("should be able to run NAT client pods", func() {
+		By("creating a NAT client pod")
+		kubectlSafe(nil, "apply", "-f", "manifests/nat-client.yaml")
+
+		By("checking the pod status")
+		Eventually(func() error {
+			pod := &corev1.Pod{}
+			err := getResource("default", "pods", "nat-client", "", pod)
+			if err != nil {
+				return err
+			}
+			if len(pod.Status.ContainerStatuses) == 0 {
+				return errors.New("no container status")
+			}
+			cst := pod.Status.ContainerStatuses[0]
+			if !cst.Ready {
+				return errors.New("container is not ready")
+			}
+			return nil
+		}).Should(Succeed())
+	})
+
+	It("should allow NAT traffic over foo-over-udp tunnel", func() {
+		var fakeIP, fakeURL string
+		if testIPv6 {
+			fakeIP = "2606:4700:4700::9999"
+			fakeURL = fmt.Sprintf("http://[%s]", fakeIP)
+		} else {
+			fakeIP = "9.9.9.9"
+			fakeURL = "http://" + fakeIP
+		}
+
+		By("setting a fake global address to coil-control-plane")
+		_, err := runOnNode("coil-control-plane", "ip", "link", "add", "dummy-fake", "type", "dummy")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = runOnNode("coil-control-plane", "ip", "link", "set", "dummy-fake", "up")
+		Expect(err).NotTo(HaveOccurred())
+		if testIPv6 {
+			_, err = runOnNode("coil-control-plane", "ip", "address", "add", fakeIP+"/128", "dev", "dummy-fake", "nodad")
+		} else {
+			_, err = runOnNode("coil-control-plane", "ip", "address", "add", fakeIP+"/32", "dev", "dummy-fake")
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		By("running HTTP server on coil-control-plane")
+		go runOnNode("coil-control-plane", "/usr/local/bin/echotest")
+		time.Sleep(100 * time.Millisecond)
+
+		By("sending and receiving HTTP request from nat-client")
+		data := make([]byte, 1<<20) // 1 MiB
+		resp := kubectlSafe(data, "exec", "-i", "nat-client", "--", "curl", "-sf", "-T", "-", fakeURL)
+		Expect(resp).To(HaveLen(1 << 20))
+
+		By("running the same test 100 times")
+		for i := 0; i < 100; i++ {
+			time.Sleep(1 * time.Millisecond)
+			resp := kubectlSafe(data, "exec", "-i", "nat-client", "--", "curl", "-sf", "-T", "-", fakeURL)
+			Expect(resp).To(HaveLen(1 << 20))
+		}
 	})
 })

--- a/v2/e2e/echo-server/main.go
+++ b/v2/e2e/echo-server/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+type echoHandler struct{}
+
+func (echoHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("content-type", "application/octet-stream")
+	w.Write(body)
+}
+
+func main() {
+	s := &http.Server{
+		Handler: echoHandler{},
+	}
+	s.ListenAndServe()
+}

--- a/v2/e2e/manifests/default_pool.yaml
+++ b/v2/e2e/manifests/default_pool.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   blockSizeBits: 0
   subnets:
-  - ipv4: 10.224.0.0/24
+  - ipv4: 10.244.0.0/24

--- a/v2/e2e/manifests/default_pool_v6.yaml
+++ b/v2/e2e/manifests/default_pool_v6.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   blockSizeBits: 0
   subnets:
-  - ipv6: fd00:10:224::/120
+  - ipv6: fd00:10:244::/120

--- a/v2/e2e/manifests/egress.yaml
+++ b/v2/e2e/manifests/egress.yaml
@@ -1,0 +1,19 @@
+apiVersion: coil.cybozu.com/v2
+kind: Egress
+metadata:
+  name: egress
+  namespace: internet
+spec:
+  replicas: 2
+  destinations:
+  - 0.0.0.0/0
+  - ::/0
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: coil-control-plane
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      containers:
+      - name: egress

--- a/v2/e2e/manifests/nat-client.yaml
+++ b/v2/e2e/manifests/nat-client.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nat-client
+  namespace: default
+  annotations:
+    egress.coil.cybozu.com/internet: egress
+spec:
+  tolerations:
+  - key: test
+    operator: Exists
+  nodeSelector:
+    test: coil
+  containers:
+  - name: ubuntu
+    image: quay.io/cybozu/ubuntu:18.04
+    command: ["pause"]

--- a/v2/pkg/constants/constants.go
+++ b/v2/pkg/constants/constants.go
@@ -51,6 +51,7 @@ const (
 	EnvAddresses    = "COIL_POD_ADDRESSES"
 	EnvPodNamespace = "COIL_POD_NAMESPACE"
 	EnvPodName      = "COIL_POD_NAME"
+	EnvEgressName   = "COIL_EGRESS_NAME"
 )
 
 // MetricsNS is the namespace for Prometheus metrics


### PR DESCRIPTION
This PR contains necessary changes to run Egress NAT feature and
adds end-to-end tests for the feature.

- The base container image is changed from scratch to Ubuntu.
    This is necessary to run `modprobe` and `iptables`.
- `coil-controller` is granted to access Pods.
    This is necessary because `coil-controller` needs to grant the same privilege to Egress pods.
- `coil-egress` is run as privileged.
    This is necessary to edit sysctl files under `/proc/sys/net`.
- `coil-egress` should use the name of Egress resource to find client pods instead of the name of itself.