### PR TITLE
coil-controller: add pool metrics

### DIFF
--- a/docs/cmd-coil-controller.md
+++ b/docs/cmd-coil-controller.md
@@ -38,3 +38,21 @@ Flags:
   -v, --version                version for coil-controller
       --webhook-addr string    bind address of admission webhook (default ":9443")
 ```
+
+## Prometheus metrics
+
+### `coil_controller_max_blocks`
+
+This is a gauge of the maximum number of allocatable address blocks of a pool.
+
+| Label  | Description   |
+| ------ | ------------- |
+| `pool` | The pool name |
+
+### `coil_controller_allocated_blocks`
+
+This is a gauge of the number of currently allocated address blocks.
+
+| Label  | Description   |
+| ------ | ------------- |
+| `pool` | The pool name |

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -29,7 +29,7 @@ require (
 	go.uber.org/zap v1.15.0
 	golang.org/x/sys v0.0.0-20200828194041-157a740278f4
 	google.golang.org/grpc v1.32.0
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200812184716-7d8921505e1b
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.0.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/ini.v1 v1.55.0 // indirect
 	k8s.io/api v0.18.8

--- a/v2/pkg/cnirpc/cni_grpc.pb.go
+++ b/v2/pkg/cnirpc/cni_grpc.pb.go
@@ -12,7 +12,7 @@ import (
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion6
+const _ = grpc.SupportPackageIsVersion7
 
 // CNIClient is the client API for CNI service.
 //
@@ -72,16 +72,23 @@ type CNIServer interface {
 type UnimplementedCNIServer struct {
 }
 
-func (*UnimplementedCNIServer) Add(context.Context, *CNIArgs) (*AddResponse, error) {
+func (UnimplementedCNIServer) Add(context.Context, *CNIArgs) (*AddResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Add not implemented")
 }
-func (*UnimplementedCNIServer) Del(context.Context, *CNIArgs) (*empty.Empty, error) {
+func (UnimplementedCNIServer) Del(context.Context, *CNIArgs) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Del not implemented")
 }
-func (*UnimplementedCNIServer) Check(context.Context, *CNIArgs) (*empty.Empty, error) {
+func (UnimplementedCNIServer) Check(context.Context, *CNIArgs) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Check not implemented")
 }
-func (*UnimplementedCNIServer) mustEmbedUnimplementedCNIServer() {}
+func (UnimplementedCNIServer) mustEmbedUnimplementedCNIServer() {}
+
+// UnsafeCNIServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to CNIServer will
+// result in compilation errors.
+type UnsafeCNIServer interface {
+	mustEmbedUnimplementedCNIServer()
+}
 
 func RegisterCNIServer(s *grpc.Server, srv CNIServer) {
 	s.RegisterService(&_CNI_serviceDesc, srv)


### PR DESCRIPTION
This PR adds metrics of address pool usage to `coil-controller`.