### PR TITLE
config: add protocol=TCP to Service

### DIFF
--- a/v2/config/webhook/service.yaml
+++ b/v2/config/webhook/service.yaml
@@ -8,5 +8,6 @@ spec:
   ports:
     - port: 443
       targetPort: 9443
+      protocol: TCP
   selector:
     app.kubernetes.io/component: coil-controller


### PR DESCRIPTION
`protocol` and `port` are required fields for server-side apply.