### PR TITLE
coil-migrator: fix replace to ignore recreated pods

### DIFF
--- a/coil-migrator/sub/replace.go
+++ b/coil-migrator/sub/replace.go
@@ -87,6 +87,11 @@ func doReplace(ctx context.Context) error {
 				if apierrors.IsNotFound(err) {
 					continue OUTER
 				}
+				if err == nil {
+					if p2.UID != pod.UID {
+						continue OUTER
+					}
+				}
 				// ignore other errors as they may be temporary
 			}
 

--- a/v2/runners/coild_server_test.go
+++ b/v2/runners/coild_server_test.go
@@ -459,6 +459,7 @@ var _ = Describe("Coild server", func() {
 		svc.Spec.Ports = []corev1.ServicePort{{Port: 8080}}
 		err = k8sClient.Create(ctx, svc)
 		Expect(err).NotTo(HaveOccurred())
+		time.Sleep(100 * time.Millisecond)
 
 		By("calling Add with IPv4 Service")
 		_, err = cniClient.Add(ctx, &cnirpc.CNIArgs{


### PR DESCRIPTION
StatefulSet controller can create new pods with the same name.
These should be ignored.