### PR TITLE
Workaround for Calico and fix PSP bugs

### DIFF
--- a/docs/cmd-coild.md
+++ b/docs/cmd-coild.md
@@ -14,6 +14,14 @@ The gRPC server provides following additional features:
 - [gRPC metrics](https://github.com/grpc-ecosystem/go-grpc-prometheus#metrics)
 - Access logging
 
+## Pod routes
+
+`coild` registers the routes to local Pods into a kernel routing table.
+The default routing table ID is **116**.
+
+This routing table is looked up by a routing rule inserted by `coild`.
+The default rule priority is **2000**.
+
 ## Route export
 
 `coild` exports address blocks owned by the running node to a kernel
@@ -44,11 +52,14 @@ Calico needs to be configured to set [`FELIX_INTERFACEPREFIX`](https://github.co
 Flags:
       --compat-calico         make veth name compatible with Calico
       --egress-port int       UDP port number for egress NAT (default 5555)
+      --export-table-id int   routing table ID to which coild exports routes (default 119)
       --health-addr string    bind address of health/readiness probes (default ":9385")
   -h, --help                  help for coild
       --metrics-addr string   bind address of metrics endpoint (default ":9384")
+      --pod-rule-prio int     priority with which the rule for Pod table is inserted (default 2000)
+      --pod-table-id int      routing table ID to which coild registers routes for Pods (default 116)
       --protocol-id int       route author ID (default 30)
+      --register-from-main    help migration from Coil 2.0.1
       --socket string         UNIX domain socket path (default "/run/coild.sock")
-      --table-id int          routing table ID to which coild exports routes (default 119)
   -v, --version               version for coild
 ```

--- a/v2/cmd/coild/sub/root.go
+++ b/v2/cmd/coild/sub/root.go
@@ -10,13 +10,16 @@ import (
 )
 
 var config struct {
-	metricsAddr  string
-	healthAddr   string
-	tableId      int
-	protocolId   int
-	socketPath   string
-	compatCalico bool
-	egressPort   int
+	metricsAddr      string
+	healthAddr       string
+	podTableId       int
+	podRulePrio      int
+	exportTableId    int
+	protocolId       int
+	socketPath       string
+	compatCalico     bool
+	egressPort       int
+	registerFromMain bool
 }
 
 var rootCmd = &cobra.Command{
@@ -46,9 +49,12 @@ func init() {
 	pf := rootCmd.PersistentFlags()
 	pf.StringVar(&config.metricsAddr, "metrics-addr", ":9384", "bind address of metrics endpoint")
 	pf.StringVar(&config.healthAddr, "health-addr", ":9385", "bind address of health/readiness probes")
-	pf.IntVar(&config.tableId, "table-id", 119, "routing table ID to which coild exports routes")
+	pf.IntVar(&config.podTableId, "pod-table-id", 116, "routing table ID to which coild registers routes for Pods")
+	pf.IntVar(&config.podRulePrio, "pod-rule-prio", 2000, "priority with which the rule for Pod table is inserted")
+	pf.IntVar(&config.exportTableId, "export-table-id", 119, "routing table ID to which coild exports routes")
 	pf.IntVar(&config.protocolId, "protocol-id", 30, "route author ID")
 	pf.StringVar(&config.socketPath, "socket", constants.DefaultSocketPath, "UNIX domain socket path")
 	pf.BoolVar(&config.compatCalico, "compat-calico", false, "make veth name compatible with Calico")
 	pf.IntVar(&config.egressPort, "egress-port", 5555, "UDP port number for egress NAT")
+	pf.BoolVar(&config.registerFromMain, "register-from-main", false, "help migration from Coil 2.0.1")
 }

--- a/v2/cmd/coild/sub/run.go
+++ b/v2/cmd/coild/sub/run.go
@@ -66,7 +66,7 @@ func subMain() error {
 		return err
 	}
 
-	exporter := nodenet.NewRouteExporter(config.tableId, config.protocolId, ctrl.Log.WithName("route-exporter"))
+	exporter := nodenet.NewRouteExporter(config.exportTableId, config.protocolId, ctrl.Log.WithName("route-exporter"))
 	nodeIPAM := ipam.NewNodeIPAM(nodeName, ctrl.Log.WithName("node-ipam"), mgr, exporter)
 	watcher := &controllers.BlockRequestWatcher{
 		Client:   mgr.GetClient(),
@@ -78,7 +78,13 @@ func subMain() error {
 		return err
 	}
 
-	podNet := nodenet.NewPodNetwork(config.protocolId, config.compatCalico, ctrl.Log.WithName("pod-network"))
+	podNet := nodenet.NewPodNetwork(
+		config.podTableId,
+		config.podRulePrio,
+		config.protocolId,
+		config.compatCalico,
+		config.registerFromMain,
+		ctrl.Log.WithName("pod-network"))
 	if err := podNet.Init(); err != nil {
 		return err
 	}

--- a/v2/config/default/pod_security_policy.yaml
+++ b/v2/config/default/pod_security_policy.yaml
@@ -116,7 +116,7 @@ metadata:
   name: coil-egress
 spec:
   privileged: true
-  allowPrivilegeEscalation: false
+  allowPrivilegeEscalation: true
   allowedCapabilities: ["NET_ADMIN"]
   volumes:
     - 'configMap'
@@ -148,7 +148,7 @@ rules:
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
-    resourceNames: ["coil-controller"]
+    resourceNames: ["coil-controller", "coil-egress"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/v2/pkg/nodenet/pod_test.go
+++ b/v2/pkg/nodenet/pod_test.go
@@ -20,7 +20,7 @@ func TestPodNetwork(t *testing.T) {
 		t.Skip("run as root")
 	}
 
-	pn := NewPodNetwork(30, false, ctrl.Log.WithName("pod-network"))
+	pn := NewPodNetwork(116, 2000, 30, false, false, ctrl.Log.WithName("pod-network"))
 	if err := pn.Init(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
When used with Calico (policy-only mode), Calico replaces Coil-created routes
in the main routing table.  It may be worked around by either:

- Configure Calico not to delete routes with [`FELIX_REMOVEEXTERNALROUTES=false`](https://docs.projectcalico.org/reference/felix/configuration)
- Do not register routes in the main routing table

This PR includes a commit to implement the second.

This also includes a commit to fix PSP problem with `coil-egress`.