### PR TITLE
coil-migrator: restart coild pods finally

### DIFF
--- a/docs/coil-migrator.md
+++ b/docs/coil-migrator.md
@@ -10,8 +10,6 @@ It has two sub commands: `dump` and `replace`.
 See [design.md](design.md#upgrading-from-v1) for the design and
 [#119](https://github.com/cybozu-go/coil/pull/119#issuecomment-704674318) for the usage.
 
-After `coil-migrator replace` succeeds, remove all `coild` Pods to restart them.
-
 ## dump sub command
 
 This command does the followings:

--- a/docs/design.md
+++ b/docs/design.md
@@ -329,11 +329,12 @@ The following steps illustrate the transition:
 6. Apply other Coil v2 resources.  This restarts Pod creation.
 7. Remove and replace Pods run by Coil v1 one by one.
 8. Remove all reserved `AddressBlocks`.
+9. Restart all `coild` Pods to resync `AddressBlocks`.
 
-A migration tool called `coil-migrator` helps step 1, 2, 3, 7, and 8.
+A migration tool called `coil-migrator` helps step 1, 2, 3, 7, 8, and 9.
 
 - `coil-migrator dump` does 1, 2, and 3.
-- `coil-migrator replace` does 7 and 8.
+- `coil-migrator replace` does 7, 8, and 9.
 
 ## Diagrams
 

--- a/v1/go.mod
+++ b/v1/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/containernetworking/cni v0.6.0
 	github.com/containernetworking/plugins v0.7.4
 	github.com/coreos/etcd v3.3.22+incompatible
+	github.com/coreos/go-iptables v0.4.2 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
-	github.com/cybozu-go/coil v1.1.7
 	github.com/cybozu-go/etcdutil v1.3.4
 	github.com/cybozu-go/log v1.6.0
 	github.com/cybozu-go/netutil v1.2.0
@@ -21,10 +21,11 @@ require (
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.2.2
-	github.com/onsi/ginkgo v1.12.0
-	github.com/onsi/gomega v1.9.0
+	github.com/onsi/ginkgo v1.12.0 // indirect
+	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
@@ -33,8 +34,8 @@ require (
 	github.com/spf13/viper v1.6.2
 	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
 	github.com/vishvananda/netlink v1.0.0
+	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
 	go.uber.org/zap v1.14.1 // indirect
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
 	golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775
 	google.golang.org/genproto v0.0.0-20200326112834-f447254575fd // indirect


### PR DESCRIPTION
coild is unable to notice that the reserved blocks have disappeared.

To unexport the reserved blocks from the kernel routing table 119,
coild needs to be restarted after the reserved blocks are deleted.