### PR TITLE
pkg/ipam: SyncPool always updates the pool information

### DIFF
--- a/v2/pkg/ipam/pool.go
+++ b/v2/pkg/ipam/pool.go
@@ -124,14 +124,10 @@ func (pm *poolManager) DropPool(name string) {
 }
 
 func (pm *poolManager) SyncPool(ctx context.Context, name string) error {
-	pm.mu.Lock()
-	p, ok := pm.pools[name]
-	pm.mu.Unlock()
-
-	if !ok {
-		return nil
+	p, err := pm.getPool(ctx, name)
+	if err != nil {
+		return err
 	}
-
 	return p.SyncBlocks(ctx)
 }
 


### PR DESCRIPTION
Previously, PoolManager.SyncPool did nothing for pools that have
not allocate blocks with AllocateBlock method.

As a consequence, coil-controller did not expose the metrics for
such pools.

This commit fixes the problem by making SyncPool always sync.