### PR TITLE
docs: purge IPVS scheduler=sh

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -227,12 +227,7 @@ To satisfy this condition, we use the port number 5555 for FoU on both client po
 To tunnel TCP packets, we need to keep sending the packets to the same SNAT router.
 This can be achieved by setting Service's [`spec.sessionAffinity`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#servicespec-v1-core) to `ClientIP`.
 
-One subtle problem of this is that the affinity can't be kept forever.
-
-- For `kube-proxy` running in iptables mode, this can be changed through `net.netfilter.nf_conntrack_udp_timeout_stream` sysctl value.
-- For `kube-proxy` running in IPVS mode, this can be changed through `net.ipv4.vs.timeout_udp` sysctl value.
-
-If `kube-proxy` runs in IPVS mode, we have an alternative method to keep sessions; use source-hash (`sh`) scheduling algorithm.  This can be done by giving `--ipvs-scheduler=sh` option to `kube-proxy`.
+Therefore, Coil creates a Service with `spec.sessionAffinity=ClientIP` for each NAT gateway.
 
 ### Auto-scaling with HPA
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -288,16 +288,22 @@ spec:
 If you set `replicas` to more than 1, normally you should not set `sessionAffinity` to `None`.
 This is because session affinity is mandatory to keep stateful TCP connections.
 
-One problem with session affinity in Kubernetes is that it limits the maximum
-duration of a session.  By default, [it is 3 hours](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#clientipconfig-v1-core).
+You may need to extend the timeout setting for idle connections with `spec.sessionAffinityConfig` as follows:
 
-If `kube-proxy` is running in IPVS mode, you can specify `--ipvs-scheduler=sh` to allow setting `sessionAffinity` to `None`.
-`sh` determines the destination server based on the client IP.
+```yaml
+apiVersion: coil.cybozu.com/v2
+kind: Egress
+metadata:
+  namespace: other-network
+  name: egress
+spec:
+  # snip
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 43200
+```
 
-For more information, read:
-
-- https://www.programmersought.com/article/28252846600/
-- https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/#options
+The default timeout seconds is 10800 (= 3 hours).
 
 [DeploymentStrategy]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#deploymentstrategy-v1-apps
 [PodTemplateSpec]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podtemplatespec-v1-core 


### PR DESCRIPTION
It has turned out that the session affinity feature of IPVS can be
kept indefinitely while packets for the session is coming/outgoing.

So, there is no need for IPVS scheduler=sh (source hash).