### PR TITLE
Add support for k8s 1.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
     name: End-to-end Test
     strategy:
       matrix:
-        kindest-node: ["kindest/node:v1.18.8", "kindest/node:v1.19.4"]
+        kindest-node: ["kindest/node:v1.18.8", "kindest/node:v1.19.4", "kindest/node:v1.20.0"]
         ip-version: ["ipv4", "ipv6"]
     runs-on: ubuntu-20.04
     steps:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Version 2 is generally available (GA).  It conforms to [CNI spec 0.4.0](https://
 
 ## Dependencies
 
-- Kubernetes Version: 1.18, 1.19
+- Kubernetes Version: 1.18, 1.19, 1.20
     - Other versions are likely to work, but not tested.
 
 - (Optional) Routing software


### PR DESCRIPTION
Run CI for Kubernetes 1.20.
No significant changes related to CNI in k8s 1.20 release notes.