### PR TITLE
egress: mount emptyDir on /run in egress pods

### DIFF
--- a/v2/controllers/egress_controller_test.go
+++ b/v2/controllers/egress_controller_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Egress reconciler", func() {
 		Expect(depl.Spec.Template.Labels).To(HaveKeyWithValue(constants.LabelAppComponent, "egress"))
 		Expect(depl.Spec.Template.Labels).To(HaveKeyWithValue(constants.LabelAppInstance, eg.Name))
 		Expect(depl.Spec.Template.Spec.ServiceAccountName).To(Equal("coil-egress"))
-		Expect(depl.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(depl.Spec.Template.Spec.Volumes).To(HaveLen(2))
 
 		var egressContainer *corev1.Container
 		for i := range depl.Spec.Template.Spec.Containers {
@@ -117,7 +117,10 @@ var _ = Describe("Egress reconciler", func() {
 		Expect(egressContainer.Image).To(Equal("coil:dev"))
 		Expect(egressContainer.Command).To(Equal([]string{"coil-egress"}))
 		Expect(egressContainer.Env).To(HaveLen(3))
-		Expect(egressContainer.VolumeMounts).To(HaveLen(1))
+		Expect(egressContainer.VolumeMounts).To(HaveLen(2))
+		Expect(egressContainer.SecurityContext).NotTo(BeNil())
+		Expect(egressContainer.SecurityContext.ReadOnlyRootFilesystem).NotTo(BeNil())
+		Expect(*egressContainer.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
 		Expect(egressContainer.Resources.Requests).To(HaveKey(corev1.ResourceCPU))
 		Expect(egressContainer.Resources.Requests).To(HaveKey(corev1.ResourceMemory))
 		Expect(egressContainer.Ports).To(HaveLen(2))
@@ -227,7 +230,7 @@ var _ = Describe("Egress reconciler", func() {
 		Expect(depl.Spec.Template.Labels).To(HaveKeyWithValue("foo", "bar"))
 		Expect(depl.Spec.Template.Labels).To(HaveKeyWithValue(constants.LabelAppName, "coil"))
 		Expect(depl.Spec.Template.Spec.SchedulerName).To(Equal("hoge-scheduler"))
-		Expect(depl.Spec.Template.Spec.Volumes).To(HaveLen(2))
+		Expect(depl.Spec.Template.Spec.Volumes).To(HaveLen(3))
 		var sidecar, egressContainer *corev1.Container
 		for i := range depl.Spec.Template.Spec.Containers {
 			if depl.Spec.Template.Spec.Containers[i].Name == "egress" {

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -36,6 +36,7 @@ require (
 	k8s.io/apimachinery v0.18.14
 	k8s.io/client-go v0.18.14
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 // indirect
+	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
 	sigs.k8s.io/controller-runtime v0.6.3
 	sigs.k8s.io/controller-tools v0.4.0
 )


### PR DESCRIPTION
coil-egress uses iptables which locks /run/xtables.lock file.
Until iptables version 1.6.2, the lock was optional.

However, iptables now requires the successful lock of the file,
so we should mount an emptyDir on /run directory.