### PR TITLE
Add coil_egress_client_pod_count metrics

### DIFF
--- a/docs/cmd-coil-egress.md
+++ b/docs/cmd-coil-egress.md
@@ -25,3 +25,14 @@ Flags:
       --metrics-addr string   bind address of metrics endpoint (default ":8080")
   -v, --version               version for coil-egress
 ```
+
+## Prometheus metrics
+
+### `coil_egress_client_pod_count`
+
+This is the number of client pods which use the egress.
+
+| Label       | Description                   |
+| ----------- | ----------------------------- |
+| `namespace` | The egress resource namespace |
+| `egress`    | The egress resource name      |


### PR DESCRIPTION
Add `coil_egress_client_pod_count` metrics, which exposes the number of client pods uses the Egress, to egress controller.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>