### PR TITLE
Use a client that reads directly from a API server when SyncBlocks synchronizes allocated field

### DIFF
--- a/v2/cmd/coil-controller/sub/run.go
+++ b/v2/cmd/coil-controller/sub/run.go
@@ -1,7 +1,6 @@
 package sub
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
@@ -76,16 +75,13 @@ func subMain() error {
 
 	// register controllers
 
-	pm := ipam.NewPoolManager(mgr.GetClient(), ctrl.Log.WithName("pool-manager"), scheme)
+	pm := ipam.NewPoolManager(mgr.GetClient(), mgr.GetAPIReader(), ctrl.Log.WithName("pool-manager"), scheme)
 	apctrl := controllers.AddressPoolReconciler{
 		Client:  mgr.GetClient(),
 		Scheme:  scheme,
 		Manager: pm,
 	}
 	if err := apctrl.SetupWithManager(mgr); err != nil {
-		return err
-	}
-	if err := ipam.SetupIndexer(context.Background(), mgr); err != nil {
 		return err
 	}
 

--- a/v2/pkg/constants/constants.go
+++ b/v2/pkg/constants/constants.go
@@ -17,11 +17,6 @@ const (
 	LabelAppComponent = "app.kubernetes.io/component"
 )
 
-// Index keys
-const (
-	IndexController = ".metadata.controller"
-)
-
 // Finalizers
 const (
 	FinCoil = "coil.cybozu.com"

--- a/v2/pkg/ipam/pool.go
+++ b/v2/pkg/ipam/pool.go
@@ -12,11 +12,9 @@ import (
 	"github.com/cybozu-go/coil/v2/pkg/constants"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -69,6 +67,7 @@ func init() {
 
 type poolManager struct {
 	client client.Client
+	reader client.Reader
 	log    logr.Logger
 	scheme *runtime.Scheme
 
@@ -77,12 +76,13 @@ type poolManager struct {
 }
 
 // NewPoolManager creates a new PoolManager.
-func NewPoolManager(cl client.Client, l logr.Logger, scheme *runtime.Scheme) PoolManager {
+func NewPoolManager(cl client.Client, r client.Reader, l logr.Logger, scheme *runtime.Scheme) PoolManager {
 	poolMaxBlocks.Reset()
 	poolAllocated.Reset()
 
 	return &poolManager{
 		client: cl,
+		reader: r,
 		log:    l,
 		scheme: scheme,
 		pools:  make(map[string]*pool),
@@ -100,6 +100,7 @@ func (pm *poolManager) getPool(ctx context.Context, name string) (*pool, error) 
 			name:            name,
 			log:             l,
 			client:          pm.client,
+			reader:          pm.reader,
 			scheme:          pm.scheme,
 			maxBlocks:       poolMaxBlocks.WithLabelValues(name),
 			allocatedBlocks: poolAllocated.WithLabelValues(name),
@@ -143,6 +144,7 @@ func (pm *poolManager) AllocateBlock(ctx context.Context, poolName, nodeName str
 type pool struct {
 	name            string
 	client          client.Client
+	reader          client.Reader
 	log             logr.Logger
 	scheme          *runtime.Scheme
 	maxBlocks       prometheus.Gauge
@@ -156,7 +158,7 @@ type pool struct {
 // This also updates the metrics of the pool.
 func (p *pool) SyncBlocks(ctx context.Context) error {
 	ap := &coilv2.AddressPool{}
-	err := p.client.Get(ctx, client.ObjectKey{Name: p.name}, ap)
+	err := p.reader.Get(ctx, client.ObjectKey{Name: p.name}, ap)
 	if err != nil {
 		p.log.Error(err, "failed to get AddressPool")
 		return err
@@ -180,8 +182,8 @@ func (p *pool) SyncBlocks(ctx context.Context) error {
 
 	p.allocated.ClearAll()
 	blocks := &coilv2.AddressBlockList{}
-	err = p.client.List(ctx, blocks, client.MatchingFields{
-		constants.IndexController: p.name,
+	err = p.reader.List(ctx, blocks, client.MatchingLabels{
+		constants.LabelPool: p.name,
 	})
 	if err != nil {
 		return err
@@ -210,7 +212,7 @@ func (p *pool) AllocateBlock(ctx context.Context, nodeName string) (*coilv2.Addr
 	}
 
 	ap := &coilv2.AddressPool{}
-	err := p.client.Get(ctx, client.ObjectKey{Name: p.name}, ap)
+	err := p.reader.Get(ctx, client.ObjectKey{Name: p.name}, ap)
 	if err != nil {
 		p.log.Error(err, "failed to get AddressPool")
 		return nil, err
@@ -270,20 +272,4 @@ func (p *pool) AllocateBlock(ctx context.Context, nodeName string) (*coilv2.Addr
 
 	p.log.Error(ErrNoBlock, "no available blocks")
 	return nil, ErrNoBlock
-}
-
-// SetupIndexer setups the required indexer for PoolManager.
-func SetupIndexer(ctx context.Context, mgr manager.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &coilv2.AddressBlock{}, constants.IndexController, func(o client.Object) []string {
-		job := o.(*coilv2.AddressBlock)
-		owner := metav1.GetControllerOf(job)
-		if owner == nil {
-			pname := job.Labels[constants.LabelPool]
-			if pname != "" {
-				return []string{pname}
-			}
-			return nil
-		}
-		return []string{owner.Name}
-	})
 }

--- a/v2/pkg/ipam/pool.go
+++ b/v2/pkg/ipam/pool.go
@@ -158,7 +158,7 @@ type pool struct {
 // This also updates the metrics of the pool.
 func (p *pool) SyncBlocks(ctx context.Context) error {
 	ap := &coilv2.AddressPool{}
-	err := p.reader.Get(ctx, client.ObjectKey{Name: p.name}, ap)
+	err := p.client.Get(ctx, client.ObjectKey{Name: p.name}, ap)
 	if err != nil {
 		p.log.Error(err, "failed to get AddressPool")
 		return err
@@ -212,7 +212,7 @@ func (p *pool) AllocateBlock(ctx context.Context, nodeName string) (*coilv2.Addr
 	}
 
 	ap := &coilv2.AddressPool{}
-	err := p.reader.Get(ctx, client.ObjectKey{Name: p.name}, ap)
+	err := p.client.Get(ctx, client.ObjectKey{Name: p.name}, ap)
 	if err != nil {
 		p.log.Error(err, "failed to get AddressPool")
 		return nil, err

--- a/v2/pkg/ipam/pool_test.go
+++ b/v2/pkg/ipam/pool_test.go
@@ -23,7 +23,7 @@ var _ = Describe("PoolManager", func() {
 
 	Context("default pool", func() {
 		It("should allocate blocks", func() {
-			pm := NewPoolManager(mgr.GetClient(), ctrl.Log.WithName("PoolManager"), scheme)
+			pm := NewPoolManager(mgr.GetClient(), mgr.GetAPIReader(), ctrl.Log.WithName("PoolManager"), scheme)
 
 			blocks := make([]*coilv2.AddressBlock, 0, 6)
 			block, err := pm.AllocateBlock(ctx, "default", "node1")
@@ -82,7 +82,7 @@ var _ = Describe("PoolManager", func() {
 
 	Context("IPv4 pool", func() {
 		It("should allocate blocks", func() {
-			pm := NewPoolManager(mgr.GetClient(), ctrl.Log.WithName("PoolManager"), scheme)
+			pm := NewPoolManager(mgr.GetClient(), mgr.GetAPIReader(), ctrl.Log.WithName("PoolManager"), scheme)
 
 			blocks := make([]*coilv2.AddressBlock, 0, 2)
 			block, err := pm.AllocateBlock(ctx, "v4", "node1")

--- a/v2/pkg/ipam/suite_test.go
+++ b/v2/pkg/ipam/suite_test.go
@@ -94,8 +94,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	ctx := context.Background()
-	err = SetupIndexer(ctx, mgr)
-	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
 		err := mgr.Start(ctx)


### PR DESCRIPTION
The default client may reads objects from stale cache, and then PoolManager keeps a stale pool. That leads to the error that fails to allocate an address block.

Fix #152 