### PR TITLE
Use supported kubectl version

### DIFF
--- a/v2/e2e/Makefile
+++ b/v2/e2e/Makefile
@@ -17,6 +17,8 @@ endif
 
 .PHONY: start
 start:
+	curl -o $(BINDIR)/kubectl -sfL https://storage.googleapis.com/kubernetes-release/release/$(subst kindest/node:,,$(IMAGE))/bin/linux/amd64/kubectl
+	chmod a+x $(BINDIR)/kubectl
 	$(KIND) create cluster --image $(IMAGE) --name coil --config $(KIND_CONFIG)
 
 .PHONY: stop
@@ -51,6 +53,5 @@ logs:
 setup:
 	mkdir -p $(BINDIR)
 	curl -o $(BINDIR)/kind -sfL https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-linux-amd64
-	curl -o $(BINDIR)/kubectl -sfL https://storage.googleapis.com/kubernetes-release/release/v$(K8S_VERSION)/bin/linux/amd64/kubectl
+	chmod a+x $(BINDIR)/kind
 	curl -sfL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(KUSTOMIZE_VERSION)/kustomize_v$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz | tar -xz -C $(BINDIR)
-	chmod a+x $(BINDIR)/kubectl $(BINDIR)/kind


### PR DESCRIPTION
Previously, ```kubectl``` version is 1.19 even when ```kube-apiserver``` is 1.22.
```kubectl``` version should be +1,0,-1 of ```kube-apiserver``` version.
https://kubernetes.io/releases/version-skew-policy/

Therefore, this patch fixes it to use the same version as ```kube-apiserver```.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>