### PR TITLE
Remove sleep from CNI DEL implementation

### DIFF
--- a/v2/runners/coild_server.go
+++ b/v2/runners/coild_server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -265,17 +264,6 @@ func (s *coildServer) Add(ctx context.Context, args *cnirpc.CNIArgs) (*cnirpc.Ad
 
 func (s *coildServer) Del(ctx context.Context, args *cnirpc.CNIArgs) (*emptypb.Empty, error) {
 	logger := ctxzap.Extract(ctx)
-
-	duration := 30 * time.Second
-	deadline, ok := ctx.Deadline()
-	if ok {
-		d2 := time.Until(deadline)
-		if d2 < (duration+1*time.Second) && d2 > time.Second {
-			duration = d2 - time.Second
-		}
-	}
-	logger.Sugar().Infow("waiting before destroying pod network", "duration", duration.String())
-	time.Sleep(duration)
 
 	if err := s.podNet.Destroy(args.ContainerId, args.Ifname); err != nil {
 		logger.Sugar().Errorw("failed to destroy pod network", "error", err)

--- a/v2/runners/coild_server_test.go
+++ b/v2/runners/coild_server_test.go
@@ -381,37 +381,31 @@ var _ = Describe("Coild server", func() {
 		Expect(err).To(HaveOccurred())
 
 		By("calling Del")
-		ctx2, cancel := context.WithTimeout(ctx, 2*time.Second)
-		_, err = cniClient.Del(ctx2, &cnirpc.CNIArgs{
+		_, err = cniClient.Del(ctx, &cnirpc.CNIArgs{
 			Args:        map[string]string{"K8S_POD_NAME": "bar", "K8S_POD_NAMESPACE": "ns2"},
 			ContainerId: "dns1",
 			Ifname:      "eth0",
 			Netns:       "/run/netns/bar",
 		})
-		cancel()
 		Expect(err).NotTo(HaveOccurred())
 
 		nodeIPAM.errFree = true
-		ctx2, cancel = context.WithTimeout(ctx, 2*time.Second)
-		_, err = cniClient.Del(ctx2, &cnirpc.CNIArgs{
+		_, err = cniClient.Del(ctx, &cnirpc.CNIArgs{
 			Args:        map[string]string{"K8S_POD_NAME": "bar", "K8S_POD_NAMESPACE": "ns2"},
 			ContainerId: "dns1",
 			Ifname:      "eth0",
 			Netns:       "/run/netns/bar",
 		})
-		cancel()
 		Expect(err).To(HaveOccurred())
 
 		nodeIPAM.errFree = false
 		podNet.errDestroy = true
-		ctx2, cancel = context.WithTimeout(ctx, 2*time.Second)
-		_, err = cniClient.Del(ctx2, &cnirpc.CNIArgs{
+		_, err = cniClient.Del(ctx, &cnirpc.CNIArgs{
 			Args:        map[string]string{"K8S_POD_NAME": "bar", "K8S_POD_NAMESPACE": "ns2"},
 			ContainerId: "dns1",
 			Ifname:      "eth0",
 			Netns:       "/run/netns/bar",
 		})
-		cancel()
 		Expect(err).To(HaveOccurred())
 	})
 


### PR DESCRIPTION
Currently, Coil sleeps 30s in its CNI DEL implementation for the graceful termination for pods. However, we recently discovered that kubelet calls the StopSandbox API of the container runtime after it stops container processes. It means container processes aren't running when the container runtime executes the CNI DEL.
Therefore, this commit removes sleep from the CNI DEL implementation because it's no longer necessary, as described above.

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>