### PR TITLE
Fix Egress NAT Deployment does not rollout restart

### DIFF
--- a/v2/controllers/egress_controller.go
+++ b/v2/controllers/egress_controller.go
@@ -113,15 +113,10 @@ func selectorLabels(name string) map[string]string {
 }
 
 func (r *EgressReconciler) reconcilePodTemplate(eg *coilv2.Egress, depl *appsv1.Deployment) {
-	tmpMap := make(map[string]string)
-	for k, v := range depl.Spec.Template.Annotations {
-		tmpMap[k] = v
-	}
 	target := &depl.Spec.Template
 	target.Labels = make(map[string]string)
-	target.Annotations = make(map[string]string)
-	for k, v := range tmpMap {
-		target.Annotations[k] = v
+	if target.Annotations == nil {
+		target.Annotations = make(map[string]string)
 	}
 
 	desired := eg.Spec.Template

--- a/v2/controllers/egress_controller.go
+++ b/v2/controllers/egress_controller.go
@@ -113,9 +113,16 @@ func selectorLabels(name string) map[string]string {
 }
 
 func (r *EgressReconciler) reconcilePodTemplate(eg *coilv2.Egress, depl *appsv1.Deployment) {
+	tmpMap := make(map[string]string)
+	for k, v := range depl.Spec.Template.Annotations {
+		tmpMap[k] = v
+	}
 	target := &depl.Spec.Template
 	target.Labels = make(map[string]string)
 	target.Annotations = make(map[string]string)
+	for k, v := range tmpMap {
+		target.Annotations[k] = v
+	}
 
 	desired := eg.Spec.Template
 	podSpec := &corev1.PodSpec{}

--- a/v2/controllers/egress_controller_test.go
+++ b/v2/controllers/egress_controller_test.go
@@ -469,7 +469,7 @@ var _ = Describe("Egress reconciler", func() {
 		Expect(saNS).To(HaveKey("egtest"))
 	})
 
-	It("should take over annotations when updated", func() {
+	It("shouldn't remove annotations when reconciling deployments", func() {
 		By("creating an Egress")
 		eg := makeEgress("eg6")
 		err := k8sClient.Create(ctx, eg)


### PR DESCRIPTION
I changed that taking over annotations when reconciling deployments to complete rollout restart.
When Egress NAT executes rollout restart, `kubectl` adds the annotation `kubectl.kubernetes.io/restartedAt` to `PodTemplateSpec`.
However coil egress controller initialized all annotations when reconciling deployments.
Therefore I fixed as described above.