### PR TITLE
Fix IPAM logic not to reuse the same addresses immediately

### DIFF
--- a/v2/pkg/ipam/allocator.go
+++ b/v2/pkg/ipam/allocator.go
@@ -12,12 +12,13 @@ type allocator struct {
 	ipv4         *net.IPNet
 	ipv6         *net.IPNet
 	usage        *bitset.BitSet
-	lastAllocIdx *int64
+	lastAllocIdx int64
 }
 
-func newAllocator(ipv4, ipv6 *string) (a allocator) {
-	var lastAllocIdx int64
-	a.lastAllocIdx = &lastAllocIdx
+func newAllocator(ipv4, ipv6 *string) *allocator {
+	a := &allocator{
+		lastAllocIdx: -1,
+	}
 	if ipv4 != nil {
 		ip, n, _ := net.ParseCIDR(*ipv4)
 		if ip.To4() == nil {
@@ -35,33 +36,32 @@ func newAllocator(ipv4, ipv6 *string) (a allocator) {
 			a.usage = bitset.New(uint(1) << (bits - ones))
 		}
 	}
-	*a.lastAllocIdx = -1
-	return
+	return a
 }
 
-func (a allocator) isFull() bool {
+func (a *allocator) isFull() bool {
 	return a.usage.All()
 }
 
-func (a allocator) isEmpty() bool {
+func (a *allocator) isEmpty() bool {
 	return a.usage.None()
 }
 
-func (a allocator) fill() {
+func (a *allocator) fill() {
 	for i := uint(0); i < a.usage.Len(); i++ {
 		a.usage.Set(i)
 	}
-	*a.lastAllocIdx = int64(a.usage.Len() - 1)
+	a.lastAllocIdx = int64(a.usage.Len() - 1)
 }
 
-func (a allocator) register(ipv4, ipv6 net.IP) (uint, bool) {
+func (a *allocator) register(ipv4, ipv6 net.IP) (uint, bool) {
 	if a.ipv4 != nil && a.ipv4.Contains(ipv4) {
 		offset := netutil.IPDiff(a.ipv4.IP, ipv4)
 		if offset < 0 {
 			panic(fmt.Sprintf("ip: %v, base: %v, offset: %v", ipv4, a.ipv4.IP, offset))
 		}
 		a.usage.Set(uint(offset))
-		*a.lastAllocIdx = int64(offset)
+		a.lastAllocIdx = int64(offset)
 		return uint(offset), true
 	}
 	if a.ipv6 != nil && a.ipv6.Contains(ipv6) {
@@ -70,15 +70,15 @@ func (a allocator) register(ipv4, ipv6 net.IP) (uint, bool) {
 			panic(fmt.Sprintf("ip: %v, base: %v, offset: %v", ipv6, a.ipv6.IP, offset))
 		}
 		a.usage.Set(uint(offset))
-		*a.lastAllocIdx = int64(offset)
+		a.lastAllocIdx = int64(offset)
 		return uint(offset), true
 	}
 	return 0, false
 }
 
-func (a allocator) allocate() (ipv4, ipv6 net.IP, idx uint, ok bool) {
+func (a *allocator) allocate() (ipv4, ipv6 net.IP, idx uint, ok bool) {
 	// try to get an usable index from the last allocated index
-	idx, ok = a.usage.NextClear(uint(*a.lastAllocIdx + 1))
+	idx, ok = a.usage.NextClear(uint(a.lastAllocIdx + 1))
 	if !ok {
 		// if an usable index is not found, try to get from index 0
 		if idx, ok = a.usage.NextClear(0); !ok {
@@ -93,10 +93,10 @@ func (a allocator) allocate() (ipv4, ipv6 net.IP, idx uint, ok bool) {
 		ipv6 = netutil.IPAdd(a.ipv6.IP, int64(idx))
 	}
 	a.usage.Set(idx)
-	*a.lastAllocIdx = int64(idx)
+	a.lastAllocIdx = int64(idx)
 	return
 }
 
-func (a allocator) free(idx uint) {
+func (a *allocator) free(idx uint) {
 	a.usage.Clear(idx)
 }

--- a/v2/pkg/ipam/allocator.go
+++ b/v2/pkg/ipam/allocator.go
@@ -62,7 +62,6 @@ func (a allocator) register(ipv4, ipv6 net.IP) (uint, bool) {
 		}
 		a.usage.Set(uint(offset))
 		*a.lastAllocIdx = int64(offset)
-		fmt.Println("register: last allocated index = ", *a.lastAllocIdx)
 		return uint(offset), true
 	}
 	if a.ipv6 != nil && a.ipv6.Contains(ipv6) {
@@ -72,7 +71,6 @@ func (a allocator) register(ipv4, ipv6 net.IP) (uint, bool) {
 		}
 		a.usage.Set(uint(offset))
 		*a.lastAllocIdx = int64(offset)
-		fmt.Println("register: last allocated index = ", *a.lastAllocIdx)
 		return uint(offset), true
 	}
 	return 0, false

--- a/v2/pkg/ipam/node.go
+++ b/v2/pkg/ipam/node.go
@@ -261,7 +261,7 @@ func (n *nodeIPAM) getPool(ctx context.Context, name string) (*nodePool, error) 
 			apiReader:           n.apiReader,
 			scheme:              n.scheme,
 			requestCompletionCh: make(chan *coilv2.BlockRequest),
-			blockAlloc:          make(map[string]allocator),
+			blockAlloc:          make(map[string]*allocator),
 		}
 		if err := p.syncBlock(ctx); err != nil {
 			return nil, err
@@ -324,7 +324,7 @@ type nodePool struct {
 	requestCompletionCh chan *coilv2.BlockRequest
 
 	mu         sync.Mutex
-	blockAlloc map[string]allocator
+	blockAlloc map[string]*allocator
 }
 
 // syncBlock synchronizes address block information.
@@ -442,7 +442,7 @@ func (p *nodePool) register(containerID, iface string, ipv4, ipv6 net.IP) *alloc
 	return nil
 }
 
-func (p *nodePool) allocateFrom(alloc allocator, block string, toSync bool) (*allocInfo, bool, error) {
+func (p *nodePool) allocateFrom(alloc *allocator, block string, toSync bool) (*allocInfo, bool, error) {
 	ipv4, ipv6, idx, ok := alloc.allocate()
 	if !ok {
 		panic("bug")

--- a/v2/pkg/ipam/node_test.go
+++ b/v2/pkg/ipam/node_test.go
@@ -60,8 +60,8 @@ func testController(ctx context.Context, npMap map[string]NodeIPAM) {
 					},
 					Finalizers: []string{constants.FinCoil},
 				},
-				Index: 0,
-				IPv4:  strPtr("10.4.0.0/32"),
+				Index: 2,
+				IPv4:  strPtr("10.4.0.0/30"),
 			},
 		},
 	}
@@ -230,14 +230,19 @@ var _ = Describe("NodeIPAM", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ipv4).To(EqualIP(net.ParseIP("10.4.0.0")))
 		Expect(ipv6).To(BeNil())
-		Expect(e2.Equal([]string{"10.4.0.0/32"})).To(BeTrue())
+		Expect(e2.Equal([]string{"10.4.0.0/30"})).To(BeTrue())
+
+		ipv4, ipv6, err = nodeIPAM2.Allocate(ctx, "v4", "d2", "eth0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ipv4).To(EqualIP(net.ParseIP("10.4.0.1")))
+		Expect(ipv6).To(BeNil())
 
 		err = nodeIPAM2.Free(ctx, "d1", "eth0")
 		Expect(err).NotTo(HaveOccurred())
 
-		ipv4, ipv6, err = nodeIPAM.Allocate(ctx, "v4", "c101", "eth0")
+		ipv4, ipv6, err = nodeIPAM2.Allocate(ctx, "v4", "c101", "eth0")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ipv4).To(EqualIP(net.ParseIP("10.4.0.0")))
+		Expect(ipv4).To(EqualIP(net.ParseIP("10.4.0.2")))
 		Expect(ipv6).To(BeNil())
 	})
 


### PR DESCRIPTION
This PR contains the change based on https://github.com/cybozu-go/coil/pull/233.

I added a `lastAllocIdx` field in `allocator` to record the last used index.
And when `coil-controller` allocates addresses, it picks next to `lastAllocIdx`.

And I added some tests for this change.

Signed-off-by: terasihma <tomoya-terashima@cybozu.co.jp>