### PR TITLE
Support for updating NAT client configuration

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -306,6 +306,17 @@ ip rule add pref 2100 table 118
 ip route add default dev tun1 table 118
 ```
 
+### NAT configuration updates
+
+Users can update the existing NAT setup by editing the `spec.destinations` and `spec.fouSourcePortAuto` in the Egress resource.
+`coild` watches the Egress resources, and if it catches the updates then updates the NAT setup in the pods running on the same node following the updated Egress.
+
+Currently, coil doesn't support updating the NAT configuration which Egress CRD does not include, such as FoU destination port, FoU peer(service ClusterIP).
+Users need to restart NAT client Pods in the cases as follows.
+
+- Change the FoU tunnel port using the flags of `coild` and `coil-egress`
+- Remove services for router Pods and k8s assigns different ClusterIPs. (NAT clients have to send encapsulated packets to the new peer)
+
 ## Garbage Collection
 
 To understand this section, you need to know the Kubernetes garbage collection and finalizers.

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -13,7 +13,7 @@ FROM --platform=$TARGETPLATFORM quay.io/cybozu/ubuntu:22.04
 LABEL org.opencontainers.image.source https://github.com/cybozu-go/coil
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends netbase kmod iptables \
+    && apt-get install -y --no-install-recommends netbase kmod iptables iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build-env /workdir/work /usr/local/coil

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -104,6 +104,7 @@ config/rbac/coild_role.yaml: $(COILD_DEPENDS)
 	-rm -rf work
 	mkdir work
 	sed '0,/^package/s/.*/package work/' controllers/blockrequest_watcher.go > work/blockrequest_watcher.go
+	sed '0,/^package/s/.*/package work/' controllers/egress_watcher.go > work/egress_watcher.go
 	sed '0,/^package/s/.*/package work/' pkg/ipam/node.go > work/node.go
 	sed '0,/^package/s/.*/package work/' runners/coild_server.go > work/coild_server.go
 	$(CONTROLLER_GEN) rbac:roleName=coild paths=./work output:stdout > $@

--- a/v2/api/v2/egress_types.go
+++ b/v2/api/v2/egress_types.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"net"
-	"reflect"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -123,15 +122,8 @@ func (es EgressSpec) validate() field.ErrorList {
 	return allErrs
 }
 
-func (es EgressSpec) validateUpdate(old EgressSpec) field.ErrorList {
-	allErrs := es.validate()
-	p := field.NewPath("spec")
-
-	if !reflect.DeepEqual(es.Destinations, old.Destinations) {
-		allErrs = append(allErrs, field.Forbidden(p.Child("destinations"), "unchangeable"))
-	}
-
-	return allErrs
+func (es EgressSpec) validateUpdate() field.ErrorList {
+	return es.validate()
 }
 
 // EgressStatus defines the observed state of Egress

--- a/v2/api/v2/egress_webhook.go
+++ b/v2/api/v2/egress_webhook.go
@@ -54,7 +54,7 @@ func (r *Egress) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Egress) ValidateUpdate(old runtime.Object) error {
-	errs := r.Spec.validateUpdate(old.(*Egress).Spec)
+	errs := r.Spec.validateUpdate()
 	if len(errs) == 0 {
 		return nil
 	}

--- a/v2/api/v2/egress_webhook_test.go
+++ b/v2/api/v2/egress_webhook_test.go
@@ -145,14 +145,14 @@ var _ = Describe("Egress Webhook", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should deny updating destinations", func() {
+	It("should allow updating destinations", func() {
 		r := makeEgress()
 		err := k8sClient.Create(ctx, r)
 		Expect(err).NotTo(HaveOccurred())
 
 		r.Spec.Destinations = append(r.Spec.Destinations, "10.10.0.0/24")
 		err = k8sClient.Update(ctx, r)
-		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should deny invalid fields on update", func() {

--- a/v2/cmd/coil-egress/sub/run.go
+++ b/v2/cmd/coil-egress/sub/run.go
@@ -84,7 +84,7 @@ func subMain() error {
 		return err
 	}
 
-	ft := founat.NewFoUTunnel(config.port, ipv4, ipv6)
+	ft := founat.NewFoUTunnel(config.port, ipv4, ipv6, nil)
 	if err := ft.Init(); err != nil {
 		return err
 	}

--- a/v2/config/rbac/coild_role.yaml
+++ b/v2/config/rbac/coild_role.yaml
@@ -25,6 +25,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - coil.cybozu.com
   resources:

--- a/v2/controllers/egress_watcher.go
+++ b/v2/controllers/egress_watcher.go
@@ -170,11 +170,15 @@ func (r *EgressWatcher) hook(gwn gwNets, log *logr.Logger) func(ipv4, ipv6 net.I
 	return func(ipv4, ipv6 net.IP) error {
 		// We assume that coild already has configured NAT for the client,
 		// so we ensure that both FoUTunnel and NATClient have been initialized.
-		ft := founat.NewFoUTunnel(r.EgressPort, ipv4, ipv6)
+		ft := founat.NewFoUTunnel(r.EgressPort, ipv4, ipv6, func(message string) {
+			log.Info(message)
+		})
 		if !ft.IsInitialized() {
 			return errors.New("fouTunnel hasn't been initialized")
 		}
-		cl := founat.NewNatClient(ipv4, ipv6, nil)
+		cl := founat.NewNatClient(ipv4, ipv6, nil, func(message string) {
+			log.Info(message)
+		})
 		initialized, err := cl.IsInitialized()
 		if !initialized {
 			return fmt.Errorf("natClient hasn't been initialized: %w", err)

--- a/v2/controllers/egress_watcher.go
+++ b/v2/controllers/egress_watcher.go
@@ -128,8 +128,7 @@ func (r *EgressWatcher) getHook(ctx context.Context, eg *coilv2.Egress, logger *
 		return nil, err
 	}
 
-	// as of k8s 1.19, dual stack Service is alpha and will be re-written
-	// in 1.20.  So, we cannot use dual stack services.
+	// See getHook in coild_server.go
 	svcIP := net.ParseIP(svc.Spec.ClusterIP)
 	if svcIP == nil {
 		return nil, fmt.Errorf("invalid ClusterIP in Service %s %s", eg.Name, svc.Spec.ClusterIP)

--- a/v2/controllers/egress_watcher.go
+++ b/v2/controllers/egress_watcher.go
@@ -1,0 +1,198 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
+	"github.com/cybozu-go/coil/v2/pkg/constants"
+	"github.com/cybozu-go/coil/v2/pkg/founat"
+	"github.com/cybozu-go/coil/v2/pkg/nodenet"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type EgressWatcher struct {
+	client.Client
+	NodeName   string
+	PodNet     nodenet.PodNetwork
+	EgressPort int
+}
+
+// +kubebuilder:rbac:groups=coil.cybozu.com,resources=egresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
+// Reconcile implements Reconciler interface.
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
+func (r *EgressWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	logger.Info("start reconciling egress")
+	eg := &coilv2.Egress{}
+	if err := r.Get(ctx, req.NamespacedName, eg); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "failed to get egress")
+		return ctrl.Result{}, err
+	}
+	if eg.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	pods := &corev1.PodList{}
+	err := r.Client.List(ctx, pods, client.MatchingFields{
+		constants.PodNodeNameKey: r.NodeName,
+	})
+	if err != nil {
+		logger.Error(err, "failed to list Pod")
+		return ctrl.Result{}, err
+	}
+
+	for _, pod := range pods.Items {
+		for k, v := range pod.Annotations {
+			if !strings.HasPrefix(k, constants.AnnEgressPrefix) {
+				continue
+			}
+
+			if k[len(constants.AnnEgressPrefix):] != eg.Namespace {
+				continue
+			}
+
+			// shortcut for the most typical case
+			if v == eg.Name {
+				// Do reconcile
+				if err := r.reconcileEgressClient(ctx, eg, &pod, &logger); err != nil {
+					logger.Error(err, "failed to reconcile Egress client pod")
+					return ctrl.Result{}, err
+				}
+				continue
+			}
+
+			for _, n := range strings.Split(v, ",") {
+				if n == eg.Name {
+					if err := r.reconcileEgressClient(ctx, eg, &pod, &logger); err != nil {
+						logger.Error(err, "failed to reconcile Egress client pod")
+						return ctrl.Result{}, err
+					}
+					continue
+				}
+			}
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *EgressWatcher) reconcileEgressClient(ctx context.Context, eg *coilv2.Egress, pod *corev1.Pod, logger *logr.Logger) error {
+	hook, err := r.getHook(ctx, eg, logger)
+	if err != nil {
+		return fmt.Errorf("failed to setup NAT hook: %w", err)
+	}
+
+	var ipv4, ipv6 net.IP
+	for _, podIP := range pod.Status.PodIPs {
+		ip := net.ParseIP(podIP.IP)
+		if ip.To4() != nil {
+			ipv4 = ip.To4()
+			continue
+		}
+		if ip.To16() != nil {
+			ipv6 = ip.To16()
+		}
+	}
+	if err := r.PodNet.Update(ipv4, ipv6, hook); err != nil {
+		return fmt.Errorf("failed to update NAT configuration: %w", err)
+	}
+
+	return nil
+}
+
+type gwNets struct {
+	gateway   net.IP
+	networks  []*net.IPNet
+	sportAuto bool
+}
+
+func (r *EgressWatcher) getHook(ctx context.Context, eg *coilv2.Egress, logger *logr.Logger) (nodenet.SetupHook, error) {
+	var gw gwNets
+	svc := &corev1.Service{}
+
+	if err := r.Get(ctx, client.ObjectKey{Namespace: eg.Namespace, Name: eg.Name}, svc); err != nil {
+		return nil, err
+	}
+
+	// as of k8s 1.19, dual stack Service is alpha and will be re-written
+	// in 1.20.  So, we cannot use dual stack services.
+	svcIP := net.ParseIP(svc.Spec.ClusterIP)
+	if svcIP == nil {
+		return nil, fmt.Errorf("invalid ClusterIP in Service %s %s", eg.Name, svc.Spec.ClusterIP)
+	}
+	var subnets []*net.IPNet
+	if ip4 := svcIP.To4(); ip4 != nil {
+		svcIP = ip4
+		for _, sn := range eg.Spec.Destinations {
+			_, subnet, err := net.ParseCIDR(sn)
+			if err != nil {
+				return nil, fmt.Errorf("invalid network in Egress %s", eg.Name)
+			}
+			if subnet.IP.To4() != nil {
+				subnets = append(subnets, subnet)
+			}
+		}
+	} else {
+		for _, sn := range eg.Spec.Destinations {
+			_, subnet, err := net.ParseCIDR(sn)
+			if err != nil {
+				return nil, fmt.Errorf("invalid network in Egress %s", eg.Name)
+			}
+			if subnet.IP.To4() == nil {
+				subnets = append(subnets, subnet)
+			}
+		}
+	}
+
+	if len(subnets) > 0 {
+		gw = gwNets{gateway: svcIP, networks: subnets, sportAuto: eg.Spec.FouSourcePortAuto}
+		return r.hook(gw, logger), nil
+	}
+
+	return nil, nil
+}
+
+func (r *EgressWatcher) hook(gwn gwNets, log *logr.Logger) func(ipv4, ipv6 net.IP) error {
+	return func(ipv4, ipv6 net.IP) error {
+		// We assume that coild already has configured NAT for the client,
+		// so we don't need to call Init functions here.
+		ft := founat.NewFoUTunnel(r.EgressPort, ipv4, ipv6)
+		cl := founat.NewNatClient(ipv4, ipv6, nil)
+
+		link, err := ft.AddPeer(gwn.gateway, gwn.sportAuto)
+		if errors.Is(err, founat.ErrIPFamilyMismatch) {
+			// ignore unsupported IP family link
+			log.Info("ignored unsupported gateway", "gw", gwn.gateway)
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := cl.AddEgress(link, gwn.networks); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+// SetupWithManager registers this with the manager.
+func (r *EgressWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&coilv2.Egress{}).
+		Complete(r)
+}

--- a/v2/controllers/egress_watcher_test.go
+++ b/v2/controllers/egress_watcher_test.go
@@ -1,0 +1,163 @@
+package controllers
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"sync"
+	"time"
+
+	current "github.com/containernetworking/cni/pkg/types/100"
+	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
+	"github.com/cybozu-go/coil/v2/pkg/indexing"
+	"github.com/cybozu-go/coil/v2/pkg/nodenet"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Egress watcher", func() {
+	ctx := context.Background()
+	podNetwork := &mockPodNetwork{ips: make(map[string]bool)}
+	var cancel context.CancelFunc
+
+	BeforeEach(func() {
+		eg := makeEgress("egress1")
+		err := k8sClient.Create(ctx, eg)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		svc := &corev1.Service{}
+		svc.Namespace = "default"
+		svc.Name = "egress1"
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		svc.Spec.Ports = []corev1.ServicePort{{
+			Port:       5555,
+			TargetPort: intstr.FromInt(5555),
+			Protocol:   corev1.ProtocolUDP,
+		}}
+		err = k8sClient.Create(ctx, svc)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		makePod("pod1", []string{"10.1.1.2", "fd01::2"}, map[string]string{
+			"default": "egress1",
+		})
+		makePod("pod2", []string{"10.1.1.3", "fd01::3"}, map[string]string{
+			"default": "egress2",
+		})
+		makePod("pod3", []string{"10.1.1.4", "fd01::4"}, map[string]string{
+			"internet": "egress1",
+		})
+
+		ctx, cancel = context.WithCancel(context.TODO())
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             scheme,
+			LeaderElection:     false,
+			MetricsBindAddress: "0",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(indexing.SetupIndexForPodByNodeName(ctx, mgr)).ToNot(HaveOccurred())
+
+		watcher := EgressWatcher{
+			Client:     mgr.GetClient(),
+			NodeName:   "coil-worker",
+			PodNet:     podNetwork,
+			EgressPort: 5555,
+		}
+		err = watcher.SetupWithManager(mgr)
+		Expect(err).ToNot(HaveOccurred())
+
+		go func() {
+			err := mgr.Start(ctx)
+			if err != nil {
+				panic(err)
+			}
+		}()
+	})
+
+	AfterEach(func() {
+		cancel()
+		err := k8sClient.DeleteAllOf(context.Background(), &corev1.Pod{}, client.InNamespace("default"))
+		Expect(err).ShouldNot(HaveOccurred())
+		err = k8sClient.DeleteAllOf(context.Background(), &coilv2.Egress{}, client.InNamespace("default"))
+		Expect(err).ShouldNot(HaveOccurred())
+		time.Sleep(10 * time.Millisecond)
+	})
+
+	It("should update a NAT setup for pod1", func() {
+		eg := &coilv2.Egress{}
+		err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "egress1"}, eg)
+		Expect(err).ToNot(HaveOccurred())
+
+		eg.Spec.FouSourcePortAuto = true
+		err = k8sClient.Update(ctx, eg)
+		Expect(err).ToNot(HaveOccurred())
+
+		// pod1 is a client of default/egress1, but pod2 and pod3 are the clients of other egresses
+		Eventually(func() bool {
+			return reflect.DeepEqual(podNetwork.updatedPodIPs(), map[string]bool{
+				"10.1.1.2": true,
+				"fd01::2":  true,
+			})
+		}).Should(BeTrue())
+
+		Consistently(func() bool {
+			return reflect.DeepEqual(podNetwork.updatedPodIPs(), map[string]bool{
+				"10.1.1.2": true,
+				"fd01::2":  true,
+			})
+		}, 5*time.Second, 1*time.Second).Should(BeTrue())
+	})
+
+})
+
+type mockPodNetwork struct {
+	nUpdate int
+	ips     map[string]bool
+
+	mu sync.Mutex
+}
+
+func (p *mockPodNetwork) Init() error {
+	panic("not implemented")
+}
+func (p *mockPodNetwork) List() ([]*nodenet.PodNetConf, error) {
+	panic("not implemented")
+}
+
+func (p *mockPodNetwork) Setup(nsPath, podName, podNS string, conf *nodenet.PodNetConf, hook nodenet.SetupHook) (*current.Result, error) {
+	panic("not implemented")
+}
+
+func (p *mockPodNetwork) Update(podIPv4, podIPv6 net.IP, hook nodenet.SetupHook) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.nUpdate++
+	p.ips[podIPv4.String()] = true
+	p.ips[podIPv6.String()] = true
+	return nil
+}
+
+func (p *mockPodNetwork) updatedPodIPs() map[string]bool {
+	m := make(map[string]bool)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for k := range p.ips {
+		m[k] = true
+	}
+	return m
+}
+
+func (p *mockPodNetwork) Check(containerId, iface string) error {
+	panic("not implemented")
+}
+
+func (p *mockPodNetwork) Destroy(containerId, iface string) error {
+	panic("not implemented")
+}

--- a/v2/controllers/mock_test.go
+++ b/v2/controllers/mock_test.go
@@ -149,6 +149,10 @@ func (t *mockFoUTunnel) Init() error {
 	panic("not implemented")
 }
 
+func (t *mockFoUTunnel) IsInitialized() bool {
+	panic("not implemented")
+}
+
 func (t *mockFoUTunnel) AddPeer(ip net.IP, sportAuto bool) (netlink.Link, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/v2/controllers/pod_watcher_test.go
+++ b/v2/controllers/pod_watcher_test.go
@@ -234,6 +234,19 @@ var _ = Describe("Pod watcher", func() {
 	})
 
 	It("should check Pod deletion", func() {
+		// Ensure the pod watcher calls AddPeer and AddClient
+		Eventually(func() bool {
+			return reflect.DeepEqual(ft.GetPeers(), map[string]bool{
+				"10.1.1.2": true,
+				"fd01::2":  true,
+				"fd01::3":  true,
+			}) && reflect.DeepEqual(eg.GetClients(), map[string]bool{
+				"10.1.1.2": true,
+				"fd01::2":  true,
+				"fd01::3":  true,
+			})
+		}).Should(BeTrue())
+
 		pod2 := &corev1.Pod{}
 		err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "pod2"}, pod2)
 		Expect(err).NotTo(HaveOccurred())

--- a/v2/controllers/pod_watcher_test.go
+++ b/v2/controllers/pod_watcher_test.go
@@ -52,6 +52,7 @@ func makePod(name string, ips []string, egresses map[string]string) {
 	var graceSeconds int64
 	pod.Spec.TerminationGracePeriodSeconds = &graceSeconds
 	pod.Spec.Containers = []corev1.Container{{Name: "c1", Image: "nginx"}}
+	pod.Spec.NodeName = "coil-worker"
 	err := k8sClient.Create(context.Background(), pod)
 	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
 

--- a/v2/e2e/manifests/egress-updated.yaml
+++ b/v2/e2e/manifests/egress-updated.yaml
@@ -1,0 +1,20 @@
+apiVersion: coil.cybozu.com/v2
+kind: Egress
+metadata:
+  name: egress
+  namespace: internet
+spec:
+  replicas: 2
+  destinations:
+  - 9.9.9.9/32
+  - 2606:4700:4700::9999/128
+  fouSourcePortAuto: true
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: coil-control-plane
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      containers:
+      - name: egress

--- a/v2/e2e/manifests/nat-client-sport-auto.yaml
+++ b/v2/e2e/manifests/nat-client-sport-auto.yaml
@@ -13,5 +13,5 @@ spec:
     test: coil
   containers:
   - name: ubuntu
-    image: quay.io/cybozu/ubuntu:22.04
+    image: quay.io/cybozu/ubuntu-debug:22.04
     command: ["pause"]

--- a/v2/e2e/manifests/nat-client.yaml
+++ b/v2/e2e/manifests/nat-client.yaml
@@ -13,5 +13,5 @@ spec:
     test: coil
   containers:
   - name: ubuntu
-    image: quay.io/cybozu/ubuntu:22.04
+    image: quay.io/cybozu/ubuntu-debug:22.04
     command: ["pause"]

--- a/v2/pkg/constants/constants.go
+++ b/v2/pkg/constants/constants.go
@@ -21,6 +21,7 @@ const (
 // Index keys
 const (
 	AddressBlockRequestKey = "address-block.request"
+	PodNodeNameKey         = "pod.node-name"
 )
 
 // Finalizers

--- a/v2/pkg/founat/client_test.go
+++ b/v2/pkg/founat/client_test.go
@@ -41,6 +41,14 @@ func testClientDual(t *testing.T) {
 
 	err = cNS.Do(func(ns.NetNS) error {
 		nc := NewNatClient(net.ParseIP("10.1.1.1"), net.ParseIP("fd02::1"), nil)
+		initialized, err := nc.IsInitialized()
+		if err != nil {
+			return err
+		}
+		if initialized {
+			return errors.New("expect not to be initialized, but it's already been done")
+		}
+
 		if err := nc.Init(); err != nil {
 			return err
 		}
@@ -112,6 +120,14 @@ func testClientDual(t *testing.T) {
 			if r.Table != 118 {
 				return errors.New("wide rule should point routing table 118")
 			}
+		}
+
+		initialized, err = nc.IsInitialized()
+		if err != nil {
+			return err
+		}
+		if !initialized {
+			return errors.New("expect to be initialized, but it's not been done")
 		}
 
 		attrs := netlink.NewLinkAttrs()
@@ -295,6 +311,14 @@ func testClientV4(t *testing.T) {
 
 	err = cNS.Do(func(ns.NetNS) error {
 		nc := NewNatClient(net.ParseIP("10.1.1.1"), nil, nil)
+		initialized, err := nc.IsInitialized()
+		if err != nil {
+			return err
+		}
+		if initialized {
+			return errors.New("expect not to be initialized, but it's already been done")
+		}
+
 		if err := nc.Init(); err != nil {
 			return err
 		}
@@ -313,6 +337,14 @@ func testClientV4(t *testing.T) {
 		}
 		if _, ok := rm[1800]; ok {
 			return errors.New("ipv6 link local rule exists")
+		}
+
+		initialized, err = nc.IsInitialized()
+		if err != nil {
+			return err
+		}
+		if !initialized {
+			return errors.New("expect to be initialized, but it's not been done")
 		}
 
 		attrs := netlink.NewLinkAttrs()
@@ -369,6 +401,14 @@ func testClientV6(t *testing.T) {
 
 	err = cNS.Do(func(ns.NetNS) error {
 		nc := NewNatClient(nil, net.ParseIP("fd02::1"), nil)
+		initialized, err := nc.IsInitialized()
+		if err != nil {
+			return err
+		}
+		if initialized {
+			return errors.New("expect not to be initialized, but it's already been done")
+		}
+
 		if err := nc.Init(); err != nil {
 			return err
 		}
@@ -387,6 +427,14 @@ func testClientV6(t *testing.T) {
 		}
 		if _, ok := rm[1800]; !ok {
 			return errors.New("no ipv6 link local rule")
+		}
+
+		initialized, err = nc.IsInitialized()
+		if err != nil {
+			return err
+		}
+		if !initialized {
+			return errors.New("expect to be initialized, but it's not been done")
 		}
 
 		attrs := netlink.NewLinkAttrs()
@@ -446,8 +494,24 @@ func testClientCustom(t *testing.T) {
 			{IP: net.ParseIP("192.168.10.0"), Mask: net.CIDRMask(24, 32)},
 			{IP: net.ParseIP("fd02::"), Mask: net.CIDRMask(16, 128)},
 		})
+		initialized, err := nc.IsInitialized()
+		if err != nil {
+			return err
+		}
+		if initialized {
+			return errors.New("expect not to be initialized, but it's already been done")
+		}
+
 		if err := nc.Init(); err != nil {
 			return err
+		}
+
+		initialized, err = nc.IsInitialized()
+		if err != nil {
+			return err
+		}
+		if !initialized {
+			return errors.New("expect to be initialized, but it's not been done")
 		}
 
 		attrs := netlink.NewLinkAttrs()

--- a/v2/pkg/founat/client_test.go
+++ b/v2/pkg/founat/client_test.go
@@ -171,6 +171,77 @@ func testClientDual(t *testing.T) {
 			return errors.New("failed to add ipv6 dst to table 118")
 		}
 
+		// Update the destinations
+		err = nc.AddEgress(link, []*net.IPNet{
+			{IP: net.ParseIP("10.1.2.0"), Mask: net.CIDRMask(24, 32)},
+			{IP: net.ParseIP("10.1.3.0"), Mask: net.CIDRMask(24, 32)},
+			{IP: net.ParseIP("9.9.9.9"), Mask: net.CIDRMask(32, 32)},
+			{IP: net.ParseIP("fd03::"), Mask: net.CIDRMask(64, 128)},
+			{IP: net.ParseIP("fd04::"), Mask: net.CIDRMask(64, 128)},
+			{IP: net.ParseIP("fd05::"), Mask: net.CIDRMask(64, 128)},
+			{IP: net.ParseIP("::"), Mask: net.CIDRMask(0, 128)},
+		})
+
+		if err != nil {
+			return fmt.Errorf("failed to add egress: %w", err)
+		}
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 2 {
+			return errors.New("failed to update ipv4 dst in table 117")
+		}
+		expectedIPs := make(map[string]struct{})
+		for _, route := range routes {
+			expectedIPs[route.Dst.IP.String()] = struct{}{}
+		}
+		if _, ok := expectedIPs["10.1.2.0"]; !ok {
+			return fmt.Errorf("wrong dst in table 117: 10.1.2.0 not included")
+		}
+		if _, ok := expectedIPs["10.1.3.0"]; !ok {
+			return fmt.Errorf("wrong dst in table 117: 10.1.3.0 not included")
+		}
+
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{Table: 118}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 1 {
+			return errors.New("failed to add ipv4 dst to table 118")
+		}
+		if !routes[0].Dst.IP.Equal(net.ParseIP("9.9.9.9")) {
+			return fmt.Errorf("wrong dst in table 118: %s", routes[0].Dst.String())
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 117}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+
+		if len(routes) != 3 {
+			return errors.New("failed to update ipv6 dst in table 117")
+		}
+		expectedIPs = make(map[string]struct{})
+		for _, route := range routes {
+			expectedIPs[route.Dst.IP.String()] = struct{}{}
+		}
+		if _, ok := expectedIPs["fd03::"]; !ok {
+			return fmt.Errorf("wrong dst in table 117: fd03:: not included")
+		}
+		if _, ok := expectedIPs["fd04::"]; !ok {
+			return fmt.Errorf("wrong dst in table 117: fd04:: not included")
+		}
+		if _, ok := expectedIPs["fd05::"]; !ok {
+			return fmt.Errorf("wrong dst in table 117: fd05:: not included")
+		}
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: 118}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		if len(routes) != 1 {
+			return errors.New("failed to add ipv6 dst to table 118")
+		}
 		// NATClient can be re-initialized
 		if err := nc.Init(); err != nil {
 			return fmt.Errorf("failed to re-initialize NATClient: %w", err)

--- a/v2/pkg/founat/client_test.go
+++ b/v2/pkg/founat/client_test.go
@@ -40,7 +40,7 @@ func testClientDual(t *testing.T) {
 	defer cNS.Close()
 
 	err = cNS.Do(func(ns.NetNS) error {
-		nc := NewNatClient(net.ParseIP("10.1.1.1"), net.ParseIP("fd02::1"), nil)
+		nc := NewNatClient(net.ParseIP("10.1.1.1"), net.ParseIP("fd02::1"), nil, nil)
 		initialized, err := nc.IsInitialized()
 		if err != nil {
 			return err
@@ -310,7 +310,7 @@ func testClientV4(t *testing.T) {
 	defer cNS.Close()
 
 	err = cNS.Do(func(ns.NetNS) error {
-		nc := NewNatClient(net.ParseIP("10.1.1.1"), nil, nil)
+		nc := NewNatClient(net.ParseIP("10.1.1.1"), nil, nil, nil)
 		initialized, err := nc.IsInitialized()
 		if err != nil {
 			return err
@@ -400,7 +400,7 @@ func testClientV6(t *testing.T) {
 	defer cNS.Close()
 
 	err = cNS.Do(func(ns.NetNS) error {
-		nc := NewNatClient(nil, net.ParseIP("fd02::1"), nil)
+		nc := NewNatClient(nil, net.ParseIP("fd02::1"), nil, nil)
 		initialized, err := nc.IsInitialized()
 		if err != nil {
 			return err
@@ -493,7 +493,7 @@ func testClientCustom(t *testing.T) {
 		nc := NewNatClient(net.ParseIP("10.1.1.1"), net.ParseIP("fd02::1"), []*net.IPNet{
 			{IP: net.ParseIP("192.168.10.0"), Mask: net.CIDRMask(24, 32)},
 			{IP: net.ParseIP("fd02::"), Mask: net.CIDRMask(16, 128)},
-		})
+		}, nil)
 		initialized, err := nc.IsInitialized()
 		if err != nil {
 			return err

--- a/v2/pkg/founat/fou.go
+++ b/v2/pkg/founat/fou.go
@@ -46,6 +46,9 @@ type FoUTunnel interface {
 	// Init starts FoU listening socket.
 	Init() error
 
+	// IsInitialized checks if this FoUTunnel has been initialized
+	IsInitialized() bool
+
 	// AddPeer setups tunnel devices to the given peer and returns them.
 	// If FoUTunnel does not setup for the IP family of the given address,
 	// this returns ErrIPFamilyMismatch error.
@@ -165,6 +168,15 @@ func (t *fouTunnel) Init() error {
 	attrs := netlink.NewLinkAttrs()
 	attrs.Name = fouDummy
 	return netlink.LinkAdd(&netlink.Dummy{LinkAttrs: attrs})
+}
+
+func (t *fouTunnel) IsInitialized() bool {
+	initialized := false
+	_, err := netlink.LinkByName(fouDummy)
+	if err == nil {
+		initialized = true
+	}
+	return initialized
 }
 
 func (t *fouTunnel) AddPeer(addr net.IP, sportAuto bool) (netlink.Link, error) {

--- a/v2/pkg/founat/fou_test.go
+++ b/v2/pkg/founat/fou_test.go
@@ -50,7 +50,7 @@ func testFoUDual(t *testing.T) {
 			return fmt.Errorf("netlink: failed to add an IPv6 address: %w", err)
 		}
 
-		fou := NewFoUTunnel(5555, net.ParseIP("127.0.0.1"), net.ParseIP("::1"))
+		fou := NewFoUTunnel(5555, net.ParseIP("127.0.0.1"), net.ParseIP("::1"), nil)
 		if fou.IsInitialized() {
 			return errors.New("expect not to be initialized, but it's already been done")
 		}
@@ -265,7 +265,7 @@ func testFoUV4(t *testing.T) {
 			return err
 		}
 
-		fou := NewFoUTunnel(5555, net.ParseIP("127.0.0.1"), nil)
+		fou := NewFoUTunnel(5555, net.ParseIP("127.0.0.1"), nil, nil)
 		if fou.IsInitialized() {
 			return errors.New("expect not to be initialized, but it's already been done")
 		}
@@ -366,7 +366,7 @@ func testFoUV6(t *testing.T) {
 			return err
 		}
 
-		fou := NewFoUTunnel(5555, nil, net.ParseIP("::1"))
+		fou := NewFoUTunnel(5555, nil, net.ParseIP("::1"), nil)
 		if fou.IsInitialized() {
 			return errors.New("expect not to be initialized, but it's already been done")
 		}

--- a/v2/pkg/founat/fou_test.go
+++ b/v2/pkg/founat/fou_test.go
@@ -76,6 +76,40 @@ func testFoUDual(t *testing.T) {
 			}
 		}
 
+		if link, err := fou.AddPeer(net.ParseIP("10.1.1.1"), false); err != nil {
+			return fmt.Errorf("failed to call AddPeer with 10.1.1.1: %w", err)
+		} else {
+			iptun, ok := link.(*netlink.Iptun)
+			if !ok {
+				return fmt.Errorf("link is not Iptun: %T", link)
+			}
+			if !iptun.Remote.Equal(net.ParseIP("10.1.1.1")) {
+				return fmt.Errorf("remote is not 10.1.1.1: %s", iptun.Remote.String())
+			}
+			if !iptun.Local.Equal(net.ParseIP("127.0.0.1")) {
+				return fmt.Errorf("local is not 127.0.0.1: %s", iptun.Local.String())
+			}
+			if iptun.EncapDport != 5555 {
+				return fmt.Errorf("iptun.EncapDport is not 5555: %d", iptun.EncapDport)
+			}
+			if iptun.EncapSport != 5555 {
+				return fmt.Errorf("iptun.EncapSport is not 5555: %d", iptun.EncapSport)
+			}
+
+			ipip4, err := netlink.LinkByName("coil_ipip4")
+			if err != nil {
+				return fmt.Errorf("failed to get coil_ipip4: %w", err)
+			}
+			iptun, ok = ipip4.(*netlink.Iptun)
+			if !ok {
+				return fmt.Errorf("link is not Iptun: %T", link)
+			}
+			if !iptun.FlowBased {
+				return errors.New("coil_ipip4 is not flow based")
+			}
+		}
+
+		// Update the encap sport setting
 		if link, err := fou.AddPeer(net.ParseIP("10.1.1.1"), true); err != nil {
 			return fmt.Errorf("failed to call AddPeer with 10.1.1.1: %w", err)
 		} else {
@@ -109,6 +143,40 @@ func testFoUDual(t *testing.T) {
 			}
 		}
 
+		if link, err := fou.AddPeer(net.ParseIP("fd02::101"), false); err != nil {
+			return fmt.Errorf("failed to call AddPeer with fd02::101: %w", err)
+		} else {
+			ip6tnl, ok := link.(*netlink.Ip6tnl)
+			if !ok {
+				return fmt.Errorf("link is not Iptun: %T", link)
+			}
+			if !ip6tnl.Remote.Equal(net.ParseIP("fd02::101")) {
+				return fmt.Errorf("remote is not fd02::101: %s", ip6tnl.Remote.String())
+			}
+			if !ip6tnl.Local.Equal(net.ParseIP("::1")) {
+				return fmt.Errorf("local is not ::1: %s", ip6tnl.Local.String())
+			}
+			if ip6tnl.EncapDport != 5555 {
+				return fmt.Errorf("ip6tnl.EncapDport is not 5555: %d", ip6tnl.EncapDport)
+			}
+			if ip6tnl.EncapSport != 5555 {
+				return fmt.Errorf("ip6tnl.EncapSport is not 5555: %d", ip6tnl.EncapSport)
+			}
+
+			ipip6, err := netlink.LinkByName("coil_ipip6")
+			if err != nil {
+				return fmt.Errorf("failed to get coil_ipip6: %w", err)
+			}
+			ip6tnl, ok = ipip6.(*netlink.Ip6tnl)
+			if !ok {
+				return fmt.Errorf("link is not Iptun: %T", link)
+			}
+			if !ip6tnl.FlowBased {
+				return errors.New("coil_ipip6 is not flow based")
+			}
+		}
+
+		// Update the encap sport setting
 		if link, err := fou.AddPeer(net.ParseIP("fd02::101"), true); err != nil {
 			return fmt.Errorf("failed to call AddPeer with fd02::101: %w", err)
 		} else {
@@ -141,7 +209,6 @@ func testFoUDual(t *testing.T) {
 				return errors.New("coil_ipip6 is not flow based")
 			}
 		}
-
 		if err := fou.DelPeer(net.ParseIP("10.1.1.1")); err != nil {
 			return fmt.Errorf("failed to call DelPeer with 10.1.1.1: %w", err)
 		}

--- a/v2/pkg/founat/fou_test.go
+++ b/v2/pkg/founat/fou_test.go
@@ -51,8 +51,16 @@ func testFoUDual(t *testing.T) {
 		}
 
 		fou := NewFoUTunnel(5555, net.ParseIP("127.0.0.1"), net.ParseIP("::1"))
+		if fou.IsInitialized() {
+			return errors.New("expect not to be initialized, but it's already been done")
+		}
+
 		if err := fou.Init(); err != nil {
 			return fmt.Errorf("fou.Init failed: %w", err)
+		}
+
+		if !fou.IsInitialized() {
+			return errors.New("expect to be initialized, but it's not been done")
 		}
 
 		// test initialization twice
@@ -258,8 +266,16 @@ func testFoUV4(t *testing.T) {
 		}
 
 		fou := NewFoUTunnel(5555, net.ParseIP("127.0.0.1"), nil)
+		if fou.IsInitialized() {
+			return errors.New("expect not to be initialized, but it's already been done")
+		}
+
 		if err := fou.Init(); err != nil {
 			return fmt.Errorf("fou.Init failed: %w", err)
+		}
+
+		if !fou.IsInitialized() {
+			return errors.New("expect to be initialized, but it's not been done")
 		}
 
 		fous, err := netlink.FouList(0)
@@ -351,8 +367,16 @@ func testFoUV6(t *testing.T) {
 		}
 
 		fou := NewFoUTunnel(5555, nil, net.ParseIP("::1"))
+		if fou.IsInitialized() {
+			return errors.New("expect not to be initialized, but it's already been done")
+		}
+
 		if err := fou.Init(); err != nil {
 			return fmt.Errorf("fou.Init failed: %w", err)
+		}
+
+		if !fou.IsInitialized() {
+			return errors.New("expect to be initialized, but it's not been done")
 		}
 
 		fous, err := netlink.FouList(0)

--- a/v2/pkg/founat/nat_test.go
+++ b/v2/pkg/founat/nat_test.go
@@ -21,12 +21,12 @@ func TestNAT(t *testing.T) {
 	defer targetNS.Close()
 
 	err := cNS.Do(func(ns.NetNS) error {
-		ft := NewFoUTunnel(5555, net.ParseIP("10.1.1.2"), net.ParseIP("fd01::102"))
+		ft := NewFoUTunnel(5555, net.ParseIP("10.1.1.2"), net.ParseIP("fd01::102"), nil)
 		if err := ft.Init(); err != nil {
 			return fmt.Errorf("ft.Init on client failed: %w", err)
 		}
 
-		nc := NewNatClient(net.ParseIP("10.1.1.2"), net.ParseIP("fd01::102"), nil)
+		nc := NewNatClient(net.ParseIP("10.1.1.2"), net.ParseIP("fd01::102"), nil, nil)
 		if err := nc.Init(); err != nil {
 			return fmt.Errorf("nc.Init failed: %w", err)
 		}
@@ -56,7 +56,7 @@ func TestNAT(t *testing.T) {
 	}
 
 	err = eNS.Do(func(ns.NetNS) error {
-		ft := NewFoUTunnel(5555, net.ParseIP("10.1.2.2"), net.ParseIP("fd01::202"))
+		ft := NewFoUTunnel(5555, net.ParseIP("10.1.2.2"), net.ParseIP("fd01::202"), nil)
 		if err := ft.Init(); err != nil {
 			return fmt.Errorf("ft.Init on egress failed: %w", err)
 		}

--- a/v2/pkg/indexing/indexing.go
+++ b/v2/pkg/indexing/indexing.go
@@ -2,9 +2,9 @@ package indexing
 
 import (
 	"context"
-
 	coilv2 "github.com/cybozu-go/coil/v2/api/v2"
 	"github.com/cybozu-go/coil/v2/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -17,5 +17,12 @@ func SetupIndexForAddressBlock(ctx context.Context, mgr manager.Manager) error {
 			return nil
 		}
 		return []string{val}
+	})
+}
+
+// SetupIndexForPodByNodeName sets up an indexer for Pod.
+func SetupIndexForPodByNodeName(ctx context.Context, mgr manager.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, &corev1.Pod{}, constants.PodNodeNameKey, func(rawObj client.Object) []string {
+		return []string{rawObj.(*corev1.Pod).Spec.NodeName}
 	})
 }

--- a/v2/pkg/nodenet/pod_test.go
+++ b/v2/pkg/nodenet/pod_test.go
@@ -121,6 +121,21 @@ func TestPodNetwork(t *testing.T) {
 		t.Error("curl to host over IPv6 failed")
 	}
 
+	err = pn.Update(podConf1.IPv4, podConf1.IPv6, func(ipv4, ipv6 net.IP) error {
+		givenIPv4 = ipv4
+		givenIPv6 = ipv6
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !givenIPv4.Equal(net.ParseIP("10.1.2.3")) {
+		t.Error("hook could not catch IPv4", givenIPv4)
+	}
+	if !givenIPv6.Equal(net.ParseIP("fd02::1")) {
+		t.Error("hook could not catch IPv6", givenIPv6)
+	}
+
 	err = pn.Check(podConf1.ContainerId, podConf1.IFace)
 	if err != nil {
 		t.Error(err)
@@ -175,6 +190,15 @@ func TestPodNetwork(t *testing.T) {
 		t.Error("ping to pod1 over IPv4 failed")
 	}
 
+	err = pn.Update(podConf2.IPv4, podConf2.IPv6, func(ipv4, ipv6 net.IP) error {
+		givenIPv4 = ipv4
+		givenIPv6 = ipv6
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	err = pn.Check(podConf2.ContainerId, podConf2.IFace)
 	if err != nil {
 		t.Error(err)
@@ -227,6 +251,15 @@ func TestPodNetwork(t *testing.T) {
 	err = exec.Command("ip", "netns", "exec", "pod3", "ping", "-c", "3", "-i", "0.2", "fd02::1").Run()
 	if err != nil {
 		t.Error("ping to pod1 over IPv6 failed")
+	}
+
+	err = pn.Update(podConf3.IPv4, podConf3.IPv6, func(ipv4, ipv6 net.IP) error {
+		givenIPv4 = ipv4
+		givenIPv6 = ipv6
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	err = pn.Check(podConf3.ContainerId, podConf3.IFace)

--- a/v2/runners/coild_server.go
+++ b/v2/runners/coild_server.go
@@ -58,12 +58,16 @@ type natSetup struct {
 
 func (n natSetup) Hook(l []GWNets, log *zap.Logger) func(ipv4, ipv6 net.IP) error {
 	return func(ipv4, ipv6 net.IP) error {
-		ft := founat.NewFoUTunnel(n.port, ipv4, ipv6)
+		ft := founat.NewFoUTunnel(n.port, ipv4, ipv6, func(message string) {
+			log.Sugar().Info(message)
+		})
 		if err := ft.Init(); err != nil {
 			return err
 		}
 
-		cl := founat.NewNatClient(ipv4, ipv6, nil)
+		cl := founat.NewNatClient(ipv4, ipv6, nil, func(message string) {
+			log.Sugar().Info(message)
+		})
 		if err := cl.Init(); err != nil {
 			return err
 		}

--- a/v2/runners/coild_server.go
+++ b/v2/runners/coild_server.go
@@ -342,8 +342,8 @@ func (s *coildServer) getHook(ctx context.Context, pod *corev1.Pod) (nodenet.Set
 				"failed to get Service "+n.String(), err.Error())
 		}
 
-		// as of k8s 1.19, dual stack Service is alpha and will be re-written
-		// in 1.20.  So, we cannot use dual stack services.
+		// coil doesn't support dual stack services for now, although it's stable from k8s 1.23
+		// https://kubernetes.io/docs/concepts/services-networking/dual-stack/
 		svcIP := net.ParseIP(svc.Spec.ClusterIP)
 		if svcIP == nil {
 			return nil, newError(codes.Internal, cnirpc.ErrorCode_INTERNAL,

--- a/v2/runners/coild_server_test.go
+++ b/v2/runners/coild_server_test.go
@@ -113,6 +113,10 @@ func (p *mockPodNetwork) Setup(nsPath, podName, podNS string, conf *nodenet.PodN
 	return &current.Result{IPs: ips}, nil
 }
 
+func (p *mockPodNetwork) Update(podIPv4, podIPv6 net.IP, hook nodenet.SetupHook) error {
+	panic("not implemented")
+}
+
 func (p *mockPodNetwork) Check(containerId, iface string) error {
 	p.nCheck++
 	if containerId == "pod1" || containerId == "dns1" {


### PR DESCRIPTION
This PR introduces the Egress modification support to allow users to update the destination and fouSourcePortAuto fields in the Egress resource. `coild` watches Egress and updates the NAT setup in the existing NAT client Pod running on the same node when the Egress is updated.