### PR TITLE
Bump version to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.5.0] - 2023-10-26
+
+### Added
+
+- Support k8s 1.27 and update dependencies (#254)
+- Support for updating NAT client configuration (#253)
+- Support automatic source port selection in UDP encapsulation (#252)
+
+### Changed
+
+- Migrate to go-grpc-middleware v2 (#255)
+
 ## [2.4.0] - 2023-07-10
 
 ### Added
@@ -199,7 +211,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 Coil version 2 is a complete rewrite of Coil version 1.
 This is the first release candidate with all the planned features implemented.
 
-[Unreleased]: https://github.com/cybozu-go/coil/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/cybozu-go/coil/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/cybozu-go/coil/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/cybozu-go/coil/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/cybozu-go/coil/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/cybozu-go/coil/compare/v2.1.4...v2.2.0

--- a/v2/kustomization.yaml
+++ b/v2/kustomization.yaml
@@ -1,6 +1,6 @@
 images:
 - name: coil
-  newTag: 2.4.0
+  newTag: 2.5.0
   newName: ghcr.io/cybozu-go/coil
 
 resources:

--- a/v2/version.go
+++ b/v2/version.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const version = "2.4.0"
+const version = "2.5.0"
 
 // Version returns the semantic versioning string of Coil.
 func Version() string {


### PR DESCRIPTION
This release contains below features.
- Kubernetes 1.27 support
- Automatic source port selection in UDP encapsulation for coil-egress