### PR TITLE
Fix to avoid adding FoU devices for pods that don't use its egress

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -21,7 +21,7 @@ PROTOC_OUTPUTS = pkg/cnirpc/cni.pb.go pkg/cnirpc/cni_grpc.pb.go ../docs/cni-grpc
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)
 PROTOC := PATH=$(PWD)/bin:'$(PATH)' $(PWD)/bin/protoc -I=$(PWD)/include:.
-PODNSLIST = pod1 pod2 pod3
+PODNSLIST = pod1 pod2 pod3 pod4 pod5 pod6
 NATNSLIST = nat-client nat-router nat-egress nat-target
 OTHERNSLIST = test-egress-dual test-egress-v4 test-egress-v6 \
 	test-client-dual test-client-v4 test-client-v6 test-client-custom \
@@ -51,7 +51,7 @@ test-nodenet:
 	for i in $@ $(PODNSLIST); do $(SUDO) ip netns add $$i; done
 	for i in $@ $(PODNSLIST); do $(SUDO) ip netns exec $$i ip link set lo up; done
 	$(SUDO) ip netns exec $@ ./nodenet.test -test.v
-	for i in $@ $(PODNSLIST); do $(SUDO) ip netns delete $$i; done
+	# for i in $@ $(PODNSLIST); do $(SUDO) ip netns delete $$i; done
 	rm -f nodenet.test
 
 .PHONY: test-founat

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -51,7 +51,7 @@ test-nodenet:
 	for i in $@ $(PODNSLIST); do $(SUDO) ip netns add $$i; done
 	for i in $@ $(PODNSLIST); do $(SUDO) ip netns exec $$i ip link set lo up; done
 	$(SUDO) ip netns exec $@ ./nodenet.test -test.v
-	# for i in $@ $(PODNSLIST); do $(SUDO) ip netns delete $$i; done
+	for i in $@ $(PODNSLIST); do $(SUDO) ip netns delete $$i; done
 	rm -f nodenet.test
 
 .PHONY: test-founat

--- a/v2/e2e/coil_test.go
+++ b/v2/e2e/coil_test.go
@@ -369,7 +369,7 @@ var _ = Describe("Coil", func() {
 		}
 
 		By("creating a dummy pod don't use egress")
-		// dummy_pod must be created after creating a net-client pod
+		// dummy pod must be created after creating a net-client pod
 		kubectlSafe(nil, "apply", "-f", "manifests/dummy_pod.yaml")
 
 		By("updating Egress in the internet namespace")

--- a/v2/e2e/coil_test.go
+++ b/v2/e2e/coil_test.go
@@ -368,6 +368,10 @@ var _ = Describe("Coil", func() {
 			Expect(resp).To(HaveLen(1 << 20))
 		}
 
+		By("creating a dummy pod don't use egress")
+		// dummy_pod must be created after creating a net-client pod
+		kubectlSafe(nil, "apply", "-f", "manifests/dummy_pod.yaml")
+
 		By("updating Egress in the internet namespace")
 		kubectlSafe(nil, "apply", "-f", "manifests/egress-updated.yaml")
 
@@ -445,6 +449,20 @@ var _ = Describe("Coil", func() {
 
 			return nil
 		}).Should(Succeed())
+
+		By("confirming that the fou device must be one in dummy_pod")
+		out, err := kubectl(nil, "exec", "dummy", "--", "ip", "-j", "link", "show")
+		Expect(err).NotTo(HaveOccurred())
+		var dummyPodLinks []link
+		err = json.Unmarshal(out, &dummyPodLinks)
+		Expect(err).NotTo(HaveOccurred())
+		fouCount := 0
+		for _, l := range dummyPodLinks {
+			if strings.HasPrefix(l.Ifname, "fou") && l.Ifname != "fou-dummy" {
+				fouCount += 1
+			}
+		}
+		Expect(fouCount).To(Equal(1))
 
 		By("sending and receiving HTTP request from nat-client")
 		data = make([]byte, 1<<20) // 1 MiB

--- a/v2/e2e/manifests/dummy_pod.yaml
+++ b/v2/e2e/manifests/dummy_pod.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nat-client
+  name: dummy 
   namespace: default
   annotations:
-    egress.coil.cybozu.com/internet: egress
+    egress.coil.cybozu.com/internet: egress-sport-auto
 spec:
   tolerations:
   - key: test

--- a/v2/e2e/manifests/nat-client-sport-auto.yaml
+++ b/v2/e2e/manifests/nat-client-sport-auto.yaml
@@ -11,6 +11,7 @@ spec:
     operator: Exists
   nodeSelector:
     test: coil
+    kubernetes.io/hostname: coil-worker2
   containers:
   - name: ubuntu
     image: quay.io/cybozu/ubuntu-debug:22.04

--- a/v2/pkg/nodenet/pod.go
+++ b/v2/pkg/nodenet/pod.go
@@ -423,7 +423,7 @@ func (pn *podNetwork) Update(podIPv4, podIPv6 net.IP, hook SetupHook) error {
 	var netNsPath string
 	for _, c := range podConfigs {
 		// When both c.IPvX and podIPvX are nil, net.IP.Equal() returns always true.
-		// Avoiding comparing nil and nil, confirm c.IPvX is not nil.
+		// Avoiding comparing nil to nil, confirm c.IPvX is not nil.
 		if (c.IPv4 != nil && c.IPv4.Equal(podIPv4)) || (c.IPv6 != nil && c.IPv6.Equal(podIPv6)) {
 			netNsPath, err = getNetNsPath(c.HostVethName)
 			if err != nil {

--- a/v2/pkg/nodenet/pod.go
+++ b/v2/pkg/nodenet/pod.go
@@ -422,7 +422,9 @@ func (pn *podNetwork) Update(podIPv4, podIPv6 net.IP, hook SetupHook) error {
 
 	var netNsPath string
 	for _, c := range podConfigs {
-		if c.IPv4.Equal(podIPv4) || c.IPv6.Equal(podIPv6) {
+		// When both c.IPvX and podIPvX are nil, net.IP.Equal() returns always true.
+		// Avoiding comparing nil and nil, confirm c.IPvX is not nil.
+		if (c.IPv4 != nil && c.IPv4.Equal(podIPv4)) || (c.IPv6 != nil && c.IPv6.Equal(podIPv6)) {
 			netNsPath, err = getNetNsPath(c.HostVethName)
 			if err != nil {
 				return err

--- a/v2/pkg/nodenet/pod.go
+++ b/v2/pkg/nodenet/pod.go
@@ -423,7 +423,7 @@ func (pn *podNetwork) Update(podIPv4, podIPv6 net.IP, hook SetupHook) error {
 	var netNsPath string
 	for _, c := range podConfigs {
 		// When both c.IPvX and podIPvX are nil, net.IP.Equal() returns always true.
-		// Avoiding comparing nil to nil, confirm c.IPvX is not nil.
+		// To avoid comparing nil to nil, confirm c.IPvX is not nil.
 		if (c.IPv4 != nil && c.IPv4.Equal(podIPv4)) || (c.IPv6 != nil && c.IPv6.Equal(podIPv6)) {
 			netNsPath, err = getNetNsPath(c.HostVethName)
 			if err != nil {

--- a/v2/pkg/nodenet/pod_test.go
+++ b/v2/pkg/nodenet/pod_test.go
@@ -291,7 +291,10 @@ func TestPodNetwork(t *testing.T) {
 		t.Error("config for pod3 not found")
 	}
 
-	// confirm to select the expected pod
+	// This test is for https://github.com/cybozu-go/coil/pull/265.
+	// Confirm to select the expected pod.
+	// In this test, the address in podConf is equal to the address in the hook function.
+	// The hook function is executed inside the pod's network namespace.
 	type addrInfo struct {
 		Family string `json:"family"`
 		Local  string `json:"local"`

--- a/v2/pkg/nodenet/pod_test.go
+++ b/v2/pkg/nodenet/pod_test.go
@@ -98,6 +98,9 @@ func TestPodNetwork(t *testing.T) {
 			if len(result.Interfaces) != 2 {
 				t.Error(`len(result.Interfaces) != 2`)
 			}
+			if len(result.IPs) != 2 {
+				t.Error(`len(result.IPs) != 2`)
+			}
 			if !result.IPs[0].Address.IP.Equal(conf.IPv4) {
 				t.Errorf(`!result.IPs[0].Address.IP.Equal("%s")`, conf.IPv4)
 			}
@@ -105,28 +108,31 @@ func TestPodNetwork(t *testing.T) {
 				t.Error(`!result.IPs[0] version != "4"`)
 			}
 			if !result.IPs[1].Address.IP.Equal(conf.IPv6) {
-				t.Errorf(`!result.IPs[1].Address.IP.Equal("%s")`, conf.IPv6)
+				t.Errorf(`result.IPs[1].Address.IP.Equal("%s")`, conf.IPv6)
 			}
 			if result.IPs[1].Address.IP.To4() != nil {
-				t.Error(`!result.IPs[1] version != "6"`)
+				t.Error(`result.IPs[1] version != "6"`)
 			}
 		} else {
 			if len(result.Interfaces) != 2 {
 				t.Error(`len(result.Interfaces) != 2`)
 			}
+			if len(result.IPs) != 1 {
+				t.Error(`len(result.IPs) != 1`)
+			}
 			if conf.IPv4 != nil {
 				if !result.IPs[0].Address.IP.Equal(conf.IPv4) {
-					t.Errorf(`!result.IPs[0].Address.IP.Equal("%s")`, conf.IPv4)
+					t.Errorf(`result.IPs[0].Address.IP.Equal("%s")`, conf.IPv4)
 				}
 				if result.IPs[0].Address.IP.To4() == nil {
-					t.Error(`!result.IPs[0] version != "4"`)
+					t.Error(`result.IPs[0] version != "4"`)
 				}
 			} else {
 				if !result.IPs[0].Address.IP.Equal(conf.IPv6) {
 					t.Errorf(`!result.IPs[0].Address.IP.Equal("%s")`, conf.IPv6)
 				}
 				if result.IPs[0].Address.IP.To4() != nil {
-					t.Error(`!result.IPs[1] version != "6"`)
+					t.Error(`result.IPs[1] version != "6"`)
 				}
 			}
 		}
@@ -409,12 +415,8 @@ func TestPodNetwork(t *testing.T) {
 
 	// check pod2 network
 	err = pn.Check(podConfMap["pod2"].ContainerId, podConfMap["pod2"].IFace)
-	if err == nil {
+	if err != errNotFound {
 		t.Fatal("pn.Check must return error because pod2 network doesn't exist")
-	} else {
-		if err != errNotFound {
-			t.Fatal("given error must be errNotFound")
-		}
 	}
 }
 


### PR DESCRIPTION
This PR is related: #253

## Background

From coil v2.5, `coild` runs `EgressWatcher` to watch `Egress` resources.

When `Egress` resources are modified(or created, deleted), EgressWatcher reflects its configuration to pods that use its Egress.

## What

When reflecting the change to the pod, EgressWatcher picks the wrong network namespace and creates a device for the wrong pod.

## Why

`EgressWatcher` gets the network namespace associated with the target pod by the pods' IP addresses.

https://github.com/cybozu-go/coil/blob/ea4d2acd1c80362477472a42bf682b5678f1aa9d/v2/pkg/nodenet/pod.go#L425

In this code, either `c.IPv4.Equal(podIPv4)`  or `c.IPv6.Equal(podIPv6)` return true in almost case.
In the case of IPv4(or IPv6) single stack, this condition always returns true, and `netNsPath` is updated in every loop.
As a result, the wrong network namespace is picked.