### PR TITLE
Make setup egress before the manager starts

### DIFF
--- a/v2/cmd/coil-egress/sub/run.go
+++ b/v2/cmd/coil-egress/sub/run.go
@@ -99,7 +99,7 @@ func subMain() error {
 		return err
 	}
 
-	if err := controllers.SetupPodWatcher(mgr, myNS, myName, ft, config.enableSportAuto, eg); err != nil {
+	if err := controllers.SetupPodWatcher(mgr, myNS, myName, ft, config.enableSportAuto, eg, nil); err != nil {
 		return err
 	}
 

--- a/v2/controllers/pod_watcher_test.go
+++ b/v2/controllers/pod_watcher_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Pod watcher", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = SetupPodWatcher(mgr, "internet", "egress2", ft, true, eg)
+		err = SetupPodWatcher(mgr, "internet", "egress2", ft, true, eg, cfg)
 		Expect(err).ToNot(HaveOccurred())
 
 		go func() {

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20230807190133-6afddb37c1f0
 	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.6.0
 	golang.org/x/sys v0.19.0
 	google.golang.org/grpc v1.63.2
 	google.golang.org/protobuf v1.33.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -220,6 +220,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This PR makes egress pod to setup fou settings before its manager starts if there is a egress client pod.
This change reduces downtime of connection between egress server and client when egress servers are rolling updated.