### PR TITLE
Add periodic nodeIPAM GC

### DIFF
--- a/v2/cmd/coild/sub/run.go
+++ b/v2/cmd/coild/sub/run.go
@@ -123,6 +123,7 @@ func subMain() error {
 				return err
 			}
 		}
+		setupLog.Info("run GC for starting up")
 		if err := nodeIPAM.GC(ctx); err != nil {
 			return err
 		}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"flag"
+	"time"
 
 	"github.com/cybozu-go/coil/v2/pkg/constants"
 	"github.com/spf13/cobra"
@@ -10,19 +11,20 @@ import (
 )
 
 type Config struct {
-	MetricsAddr      string
-	HealthAddr       string
-	PodTableId       int
-	PodRulePrio      int
-	ExportTableId    int
-	ProtocolId       int
-	SocketPath       string
-	CompatCalico     bool
-	EgressPort       int
-	RegisterFromMain bool
-	ZapOpts          zap.Options
-	EnableIPAM       bool
-	EnableEgress     bool
+	MetricsAddr            string
+	HealthAddr             string
+	PodTableId             int
+	PodRulePrio            int
+	ExportTableId          int
+	ProtocolId             int
+	SocketPath             string
+	CompatCalico           bool
+	EgressPort             int
+	RegisterFromMain       bool
+	ZapOpts                zap.Options
+	EnableIPAM             bool
+	EnableEgress           bool
+	AddressBlockGCInterval time.Duration
 }
 
 func Parse(rootCmd *cobra.Command) *Config {
@@ -40,6 +42,7 @@ func Parse(rootCmd *cobra.Command) *Config {
 	pf.BoolVar(&config.RegisterFromMain, "register-from-main", constants.DefaultRegisterFromMain, "help migration from Coil 2.0.1")
 	pf.BoolVar(&config.EnableIPAM, "enable-ipam", constants.DefaultEnableIPAM, "enable IPAM related features")
 	pf.BoolVar(&config.EnableEgress, "enable-egress", constants.DefaultEnableEgress, "enable IPAM related features")
+	pf.DurationVar(&config.AddressBlockGCInterval, "addressblock-gc-interval", constants.DefaultAddressBlockGCInterval, "interval for address block GC")
 
 	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(goflags)

--- a/v2/pkg/constants/constants.go
+++ b/v2/pkg/constants/constants.go
@@ -1,5 +1,7 @@
 package constants
 
+import "time"
+
 // annotation keys
 const (
 	AnnPool         = "coil.cybozu.com/pool"
@@ -64,17 +66,18 @@ const (
 
 // Default config values
 const (
-	DefautlMetricsAddr      = ":9384"
-	DefautlHealthAddr       = ":9385"
-	DefautlPodTableId       = 116
-	DefautlPodRulePrio      = 2000
-	DefautlExportTableId    = 119
-	DefautlProtocolId       = 30
-	DefaultCompatCalico     = false
-	DefaultEgressPort       = 5555
-	DefaultRegisterFromMain = false
-	DefaultEnableIPAM       = true
-	DefaultEnableEgress     = true
+	DefautlMetricsAddr            = ":9384"
+	DefautlHealthAddr             = ":9385"
+	DefautlPodTableId             = 116
+	DefautlPodRulePrio            = 2000
+	DefautlExportTableId          = 119
+	DefautlProtocolId             = 30
+	DefaultCompatCalico           = false
+	DefaultEgressPort             = 5555
+	DefaultRegisterFromMain       = false
+	DefaultEnableIPAM             = true
+	DefaultEnableEgress           = true
+	DefaultAddressBlockGCInterval = 5 * time.Minute
 )
 
 // MetricsNS is the namespace for Prometheus metrics

--- a/v2/runners/coild_server_test.go
+++ b/v2/runners/coild_server_test.go
@@ -225,18 +225,19 @@ var _ = Describe("Coild server", func() {
 		logbuf = &bytes.Buffer{}
 		logger := zap.NewRaw(zap.WriteTo(logbuf), zap.StacktraceLevel(zapcore.DPanicLevel))
 		cfg := &config.Config{
-			MetricsAddr:      constants.DefautlMetricsAddr,
-			HealthAddr:       constants.DefautlMetricsAddr,
-			PodTableId:       constants.DefautlPodTableId,
-			PodRulePrio:      constants.DefautlPodRulePrio,
-			ExportTableId:    constants.DefautlExportTableId,
-			ProtocolId:       constants.DefautlProtocolId,
-			SocketPath:       constants.DefaultSocketPath,
-			CompatCalico:     constants.DefaultCompatCalico,
-			EgressPort:       constants.DefaultEgressPort,
-			RegisterFromMain: constants.DefaultRegisterFromMain,
-			EnableIPAM:       testIPAM,
-			EnableEgress:     testEgress,
+			MetricsAddr:            constants.DefautlMetricsAddr,
+			HealthAddr:             constants.DefautlMetricsAddr,
+			PodTableId:             constants.DefautlPodTableId,
+			PodRulePrio:            constants.DefautlPodRulePrio,
+			ExportTableId:          constants.DefautlExportTableId,
+			ProtocolId:             constants.DefautlProtocolId,
+			SocketPath:             constants.DefaultSocketPath,
+			CompatCalico:           constants.DefaultCompatCalico,
+			EgressPort:             constants.DefaultEgressPort,
+			RegisterFromMain:       constants.DefaultRegisterFromMain,
+			EnableIPAM:             testIPAM,
+			EnableEgress:           testEgress,
+			AddressBlockGCInterval: 10 * time.Second,
 		}
 
 		serv := NewCoildServer(l, mgr, nodeIPAM, podNet, natsetup, cfg, logger, mockAlias)


### PR DESCRIPTION
This PR fixes https://github.com/cybozu-go/coil/issues/271.

Up until now, nodeIPAM GC was triggered only in a start-up procedure, but now it is triggered periodically.

We introduce the new coild flag named `addressblock-gc-interval` to set the nodeIPAM GC interval and default is 5 minutes.

Signed-off-by: terashima <tomoya-terashima@cybozu.co.jp>
