### PR TITLE
Test with Ordered option

### DIFF
--- a/v2/controllers/pod_watcher_test.go
+++ b/v2/controllers/pod_watcher_test.go
@@ -79,7 +79,7 @@ coil_egress_client_pod_count{egress="egress2",namespace="internet"} %d
 	return testutil.GatherAndCompare(metrics.Registry, expected, "coil_egress_client_pod_count")
 }
 
-var _ = Describe("Pod watcher", func() {
+var _ = Describe("Pod watcher", Ordered, func() {
 	ctx := context.Background()
 	var cancel context.CancelFunc
 	var ft *mockFoUTunnel

--- a/v2/e2e/coil_test.go
+++ b/v2/e2e/coil_test.go
@@ -26,10 +26,10 @@ var (
 
 var _ = Describe("coil", func() {
 	if enableIPAMTests {
-		Context("when the IPAM features are enabled", testIPAM)
+		Context("when the IPAM features are enabled", Ordered, testIPAM)
 	}
 	if enableEgressTests {
-		Context("when egress feature is enabled", testEgress)
+		Context("when egress feature is enabled", Ordered, testEgress)
 	}
 	Context("when coild is deployed", testCoild)
 })

--- a/v2/e2e/controller_test.go
+++ b/v2/e2e/controller_test.go
@@ -20,10 +20,10 @@ const (
 
 var _ = Describe("coil controllers", func() {
 	if os.Getenv(testIPAMKey) == "true" {
-		Context("when the IPAM features are enabled", testCoilIPAMController)
+		Context("when the IPAM features are enabled", Ordered, testCoilIPAMController)
 	}
 	if os.Getenv(testEgressKey) == "true" {
-		Context("when egress feature is enabled", testCoilEgressController)
+		Context("when egress feature is enabled", Ordered, testCoilEgressController)
 	}
 })
 


### PR DESCRIPTION
Some tests are expected to be tested in the order they are written, but the order of execution of It() is not determined.
Therefore order-sensitive tests was failing flaky.
e.g. https://github.com/cybozu-go/coil/actions/runs/14495849428/job/40663286944?pr=324

This PR add `Ordered` decoration to order-sensitive tests.