### PR TITLE
egress: Add new iptabels rule for dropping invalid packets

### DIFF
--- a/v2/pkg/founat/egress.go
+++ b/v2/pkg/founat/egress.go
@@ -76,8 +76,7 @@ func (e *egress) Init() error {
 		if err != nil {
 			return fmt.Errorf("failed to setup masquerade rule for IPv4: %w", err)
 		}
-		err = ipt.Append("filter", "FORWARD", "-o", e.iface, "-m", "state", "--state", "INVALID", "-j", "DROP")
-		if err != nil {
+		if err := ipt.Append("filter", "FORWARD", "-o", e.iface, "-m", "state", "--state", "INVALID", "-j", "DROP"); err != nil {
 			return fmt.Errorf("failed to setup drop rule for invalid packets: %w", err)
 		}
 
@@ -96,8 +95,7 @@ func (e *egress) Init() error {
 		if err != nil {
 			return fmt.Errorf("failed to setup masquerade rule for IPv6: %w", err)
 		}
-		err = ipt.Append("filter", "FORWARD", "-o", e.iface, "-m", "state", "--state", "INVALID", "-j", "DROP")
-		if err != nil {
+		if err := ipt.Append("filter", "FORWARD", "-o", e.iface, "-m", "state", "--state", "INVALID", "-j", "DROP"); err != nil {
 			return fmt.Errorf("failed to setup drop rule for invalid packets: %w", err)
 		}
 

--- a/v2/pkg/founat/egress.go
+++ b/v2/pkg/founat/egress.go
@@ -76,6 +76,10 @@ func (e *egress) Init() error {
 		if err != nil {
 			return fmt.Errorf("failed to setup masquerade rule for IPv4: %w", err)
 		}
+		err = ipt.Append("filter", "FORWARD", "-o", e.iface, "-m", "state", "--state", "INVALID", "-j", "DROP")
+		if err != nil {
+			return fmt.Errorf("failed to setup drop rule for invalid packets: %w", err)
+		}
 
 		rule := e.newRule(netlink.FAMILY_V4)
 		if err := netlink.RuleAdd(rule); err != nil {
@@ -91,6 +95,10 @@ func (e *egress) Init() error {
 		err = ipt.Append("nat", "POSTROUTING", "!", "-s", ipn.String(), "-o", e.iface, "-j", "MASQUERADE")
 		if err != nil {
 			return fmt.Errorf("failed to setup masquerade rule for IPv6: %w", err)
+		}
+		err = ipt.Append("filter", "FORWARD", "-o", e.iface, "-m", "state", "--state", "INVALID", "-j", "DROP")
+		if err != nil {
+			return fmt.Errorf("failed to setup drop rule for invalid packets: %w", err)
 		}
 
 		rule := e.newRule(netlink.FAMILY_V6)

--- a/v2/pkg/founat/egress_test.go
+++ b/v2/pkg/founat/egress_test.go
@@ -48,6 +48,13 @@ func testEgressDual(t *testing.T) {
 		if !exist {
 			return errors.New("NAT rule not found for IPv4")
 		}
+		exist, err = ipt.Exists("filter", "FORWARD", "-o", "lo", "-m", "state", "--state", "INVALID", "-j", "DROP")
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return errors.New("Filter rule not found for IPv4")
+		}
 
 		ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
 		if err != nil {
@@ -59,6 +66,14 @@ func testEgressDual(t *testing.T) {
 		}
 		if !exist {
 			return errors.New("NAT rule not found for IPv6")
+		}
+
+		exist, err = ipt.Exists("filter", "FORWARD", "-o", "lo", "-m", "state", "--state", "INVALID", "-j", "DROP")
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return errors.New("Filter rule not found for IPv6")
 		}
 
 		rm, err := ruleMap(netlink.FAMILY_V4)
@@ -168,6 +183,14 @@ func testEgressV4(t *testing.T) {
 			return errors.New("NAT rule not found for IPv4")
 		}
 
+		exist, err = ipt.Exists("filter", "FORWARD", "-o", "lo", "-m", "state", "--state", "INVALID", "-j", "DROP")
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return errors.New("Filter rule not found for IPv4")
+		}
+
 		ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
 		if err != nil {
 			return err
@@ -178,6 +201,14 @@ func testEgressV4(t *testing.T) {
 		}
 		if exist {
 			return errors.New("NAT rule found for IPv6")
+		}
+
+		exist, err = ipt.Exists("filter", "FORWARD", "-o", "lo", "-m", "state", "--state", "INVALID", "-j", "DROP")
+		if err != nil {
+			return err
+		}
+		if exist {
+			return errors.New("Filter rule found for IPv6")
 		}
 
 		rm, err := ruleMap(netlink.FAMILY_V4)
@@ -256,6 +287,14 @@ func testEgressV6(t *testing.T) {
 			return errors.New("NAT rule found for IPv4")
 		}
 
+		exist, err = ipt.Exists("filter", "FORWARD", "-o", "lo", "-m", "state", "--state", "INVALID", "-j", "DROP")
+		if err != nil {
+			return err
+		}
+		if exist {
+			return errors.New("Filter rule found for IPv4")
+		}
+
 		ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
 		if err != nil {
 			return err
@@ -266,6 +305,14 @@ func testEgressV6(t *testing.T) {
 		}
 		if !exist {
 			return errors.New("NAT rule not found for IPv6")
+		}
+
+		exist, err = ipt.Exists("filter", "FORWARD", "-o", "lo", "-m", "state", "--state", "INVALID", "-j", "DROP")
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return errors.New("Filter rule not found for IPv6")
 		}
 
 		rm, err := ruleMap(netlink.FAMILY_V4)


### PR DESCRIPTION
This PR adds new iptables rule in egress NAT pods to drop invalid packets.

The specific added rule is here.
```
iptables -t filter -A FORWARD -o <interface> -m state --state INVALID -j DROP
```

Signed-off-by: terashima <tomoya-terashima@cybozu.co.jp>
