### PR TITLE
Fix manifests under config/cke

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -296,7 +296,7 @@ define comment_certs
     $(eval $@_FILE = $(1))
 	@sed -i -E "{s/(^patchesStrategicMerge.*)/# \1/}" ${$@_FILE}
 	@sed -i -E "{s/(^-.*webhook_manifests_patch.*)/# \1/}" ${$@_FILE}
-endef    
+endef
 
 .PHONY: enable-certs-rotation
 enable-certs-rotation:

--- a/v2/config/cke/kustomization.yaml
+++ b/v2/config/cke/kustomization.yaml
@@ -2,7 +2,8 @@ resources:
 - ../crd
 - ../rbac
 - ../pod
-- ../webhook
+- ../webhook/egress
+- ../webhook/ipam
 - ./webhook-secret.yaml
 
 patchesStrategicMerge:

--- a/v2/config/cke/webhook_manifests_patch.yaml
+++ b/v2/config/cke/webhook_manifests_patch.yaml
@@ -1,14 +1,28 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: coilv2-mutating-webhook-configuration
+  name: mutating-ipam-webhook-configuration
   annotations:
     cke.cybozu.com/inject-cacert: "true"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: coilv2-validating-webhook-configuration
+  name: validating-ipam-webhook-configuration
+  annotations:
+    cke.cybozu.com/inject-cacert: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-egress-webhook-configuration
+  annotations:
+    cke.cybozu.com/inject-cacert: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-egress-webhook-configuration
   annotations:
     cke.cybozu.com/inject-cacert: "true"
 ---

--- a/v2/e2e/Makefile
+++ b/v2/e2e/Makefile
@@ -14,20 +14,20 @@ ifeq ($(TEST_IPV6),true)
 		ifeq ($(IPV6_PRIMARY),true)
 			ifeq ($(WITH_KINDNET),true)
 				KIND_CONFIG = kind-config_dualstack_v6_kindnet.yaml
-			else 
+			else
 				KIND_CONFIG = kind-config_dualstack_v6.yaml
 			endif
 		else
 			ifeq ($(WITH_KINDNET),true)
 				KIND_CONFIG = kind-config_dualstack_kindnet.yaml
-			else 
+			else
 				KIND_CONFIG = kind-config_dualstack.yaml
 			endif
 		endif
 	else
 		ifeq ($(WITH_KINDNET),true)
 			KIND_CONFIG = kind-config_kindnet_v6.yaml
-		else 
+		else
 			KIND_CONFIG = kind-config_v6.yaml
 		endif
 	endif
@@ -131,7 +131,7 @@ define comment_certs
     $(eval $@_FILE = $(1))
 	@sed -i -E "{s/(^patchesStrategicMerge.*)/# \1/}" ${$@_FILE}
 	@sed -i -E "{s/(^-.*webhook_manifests_patch.*)/# \1/}" ${$@_FILE}
-endef    
+endef
 
 .PHONY: enable-certs-rotation
 enable-certs-rotation:


### PR DESCRIPTION
This PR fixes Kustomize-related files under v2/config/cke to address changes introduced in Coil v2.9.0.
These changes only affect users of CKE-managed clusters.

To generate manifests, run the following command.
```bash
$ kustomize build v2/config/cke --load-restrictor=LoadRestrictionsNone
```

Signed-off-by: terashima <tomoya-terashima@cybozu.co.jp>
