### PR TITLE
Introduce egress metrics to count invalid packets and bytes

### DIFF
--- a/docs/cmd-coil-egress.md
+++ b/docs/cmd-coil-egress.md
@@ -95,3 +95,26 @@ This value is from the result of `iptables -t nat -L POSTROUTING -vn`.
 | `namespace` | The egress resource namespace |
 | `egress`    | The egress resource name      |
 | `pod`       | The pod name                  |
+
+### `coil_egress_nftables_invalid_packets_total`
+
+This is the total number of packets dropped as invalid packets by iptables in a egress NAT pod.
+This value is from the result of `iptables -t filter -L -vn`.
+
+| Label       | Description                   |
+| ----------- | ----------------------------- |
+| `namespace` | The egress resource namespace |
+| `egress`    | The egress resource name      |
+| `pod`       | The pod name                  |
+
+### `coil_egress_nftables_invalid_bytes_total`
+
+This is the total bytes of packets dropped as invalid packets by iptables in a egress NAT pod.
+This value is from the result of `iptables -t filter -L -vn`.
+
+| Label       | Description                   |
+| ----------- | ----------------------------- |
+| `namespace` | The egress resource namespace |
+| `egress`    | The egress resource name      |
+| `pod`       | The pod name                  |
+

--- a/v2/cmd/coil-egress/sub/run.go
+++ b/v2/cmd/coil-egress/sub/run.go
@@ -41,6 +41,8 @@ func init() {
 	metrics.Registry.MustRegister(egressMetrics.NfConnctackLimit)
 	metrics.Registry.MustRegister(egressMetrics.NfTableMasqueradeBytes)
 	metrics.Registry.MustRegister(egressMetrics.NfTableMasqueradePackets)
+	metrics.Registry.MustRegister(egressMetrics.NfTableInvalidBytes)
+	metrics.Registry.MustRegister(egressMetrics.NfTableInvalidPackets)
 }
 
 func subMain() error {

--- a/v2/pkg/metrics/collector.go
+++ b/v2/pkg/metrics/collector.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Collector interface {
-	Update() error
+	Update(ctx context.Context) error
 	Name() string
 }
 
@@ -44,7 +44,7 @@ func (r *Runner) collect(ctx context.Context) {
 	wg.Add(len(r.collectors))
 	for _, c := range r.collectors {
 		go func(c Collector) {
-			if err := c.Update(); err != nil {
+			if err := c.Update(ctx); err != nil {
 				logger.Error(err, "failed to collect metrics", "name", c.Name())
 			}
 			wg.Done()

--- a/v2/pkg/metrics/egress.go
+++ b/v2/pkg/metrics/egress.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strconv"
@@ -99,7 +100,7 @@ func (c *egressCollector) Name() string {
 	return "egress-collector"
 }
 
-func (c *egressCollector) Update() error {
+func (c *egressCollector) Update(ctx context.Context) error {
 
 	val, err := readUintFromFile(NF_CONNTRACK_COUNT_PATH)
 	if err != nil {
@@ -115,14 +116,14 @@ func (c *egressCollector) Update() error {
 
 	natPackets, natBytes, err := c.getNfTablesNATCounter()
 	if err != nil {
-		return nil
+		return err
 	}
 	c.nfTablesNATPackets.Set(float64(natPackets))
 	c.nfTablesNATBytes.Set(float64(natBytes))
 
 	invalidPackets, invalidBytes, err := c.getNfTablesInvalidCounter()
 	if err != nil {
-		return nil
+		return err
 	}
 	c.nfTablesInvalidPackets.Set(float64(invalidPackets))
 	c.nfTablesInvalidBytes.Set(float64(invalidBytes))


### PR DESCRIPTION
This PR is a follow up PR of https://github.com/cybozu-go/coil/pull/329.

We introduce following metrics.

- `coil_egress_nftables_invalid_packets_total`
- `coil_egress_nftables_invalid_bytes_total`

Signed-off-by: terashima <tomoya-terashima@cybozu.co.jp>
