### PR TITLE
Support IPv6 for egress metrics

### DIFF
--- a/docs/cmd-coil-egress.md
+++ b/docs/cmd-coil-egress.md
@@ -84,7 +84,7 @@ This value is from the result of `iptables -t nat -L POSTROUTING -vn`.
 | `namespace` | The egress resource namespace |
 | `egress`    | The egress resource name      |
 | `pod`       | The pod name                  |
-| `protocol`  | Protocol name                 |
+| `protocol`  | The protocol name                 |
 
 ### `coil_egress_nftables_masqueraded_bytes_total`
 
@@ -96,7 +96,7 @@ This value is from the result of `iptables -t nat -L POSTROUTING -vn`.
 | `namespace` | The egress resource namespace |
 | `egress`    | The egress resource name      |
 | `pod`       | The pod name                  |
-| `protocol`  | Protocol name                 |
+| `protocol`  | The protocol name                 |
 
 ### `coil_egress_nftables_invalid_packets_total`
 
@@ -108,7 +108,7 @@ This value is from the result of `iptables -t filter -L -vn`.
 | `namespace` | The egress resource namespace |
 | `egress`    | The egress resource name      |
 | `pod`       | The pod name                  |
-| `protocol`  | Protocol name                 |
+| `protocol`  | The protocol name                 |
 
 ### `coil_egress_nftables_invalid_bytes_total`
 
@@ -120,5 +120,5 @@ This value is from the result of `iptables -t filter -L -vn`.
 | `namespace` | The egress resource namespace |
 | `egress`    | The egress resource name      |
 | `pod`       | The pod name                  |
-| `protocol`  | Protocol name                 |
+| `protocol`  | The protocol name                 |
 

--- a/docs/cmd-coil-egress.md
+++ b/docs/cmd-coil-egress.md
@@ -84,6 +84,7 @@ This value is from the result of `iptables -t nat -L POSTROUTING -vn`.
 | `namespace` | The egress resource namespace |
 | `egress`    | The egress resource name      |
 | `pod`       | The pod name                  |
+| `protocol`  | Protocol name                 |
 
 ### `coil_egress_nftables_masqueraded_bytes_total`
 
@@ -95,6 +96,7 @@ This value is from the result of `iptables -t nat -L POSTROUTING -vn`.
 | `namespace` | The egress resource namespace |
 | `egress`    | The egress resource name      |
 | `pod`       | The pod name                  |
+| `protocol`  | Protocol name                 |
 
 ### `coil_egress_nftables_invalid_packets_total`
 
@@ -106,6 +108,7 @@ This value is from the result of `iptables -t filter -L -vn`.
 | `namespace` | The egress resource namespace |
 | `egress`    | The egress resource name      |
 | `pod`       | The pod name                  |
+| `protocol`  | Protocol name                 |
 
 ### `coil_egress_nftables_invalid_bytes_total`
 
@@ -117,4 +120,5 @@ This value is from the result of `iptables -t filter -L -vn`.
 | `namespace` | The egress resource namespace |
 | `egress`    | The egress resource name      |
 | `pod`       | The pod name                  |
+| `protocol`  | Protocol name                 |
 

--- a/v2/cmd/coil-egress/sub/run.go
+++ b/v2/cmd/coil-egress/sub/run.go
@@ -63,6 +63,7 @@ func subMain() error {
 		return errors.New(constants.EnvAddresses + " environment variable must be set")
 	}
 	var ipv4, ipv6 net.IP
+	protocolMap := make(map[string]struct{})
 	for _, addr := range myAddresses {
 		n := net.ParseIP(addr)
 		if n == nil {
@@ -70,9 +71,16 @@ func subMain() error {
 		}
 		if n4 := n.To4(); n4 != nil {
 			ipv4 = n4
+			protocolMap["ipv4"] = struct{}{}
 		} else {
 			ipv6 = n
+			protocolMap["ipv6"] = struct{}{}
 		}
+	}
+
+	protocols := make([]string, 0, 0)
+	for protocol, _ := range protocolMap {
+		protocols = append(protocols, protocol)
 	}
 
 	setupLog.Info("detected local IP addresses", "ipv4", ipv4.String(), "ipv6", ipv6.String())
@@ -117,7 +125,7 @@ func subMain() error {
 
 	setupLog.Info("setup egress metrics collector")
 	runner := egressMetrics.NewRunner()
-	egressCollector, err := egressMetrics.NewEgressCollector(myNS, os.Getenv("HOSTNAME"), myName)
+	egressCollector, err := egressMetrics.NewEgressCollector(myNS, os.Getenv("HOSTNAME"), myName, protocols)
 	if err != nil {
 		return err
 	}

--- a/v2/cmd/coil-egress/sub/run.go
+++ b/v2/cmd/coil-egress/sub/run.go
@@ -37,8 +37,8 @@ func init() {
 
 	// +kubebuilder:scaffold:scheme
 
-	metrics.Registry.MustRegister(egressMetrics.NfConnctackCount)
-	metrics.Registry.MustRegister(egressMetrics.NfConnctackLimit)
+	metrics.Registry.MustRegister(egressMetrics.NfConnctrackCount)
+	metrics.Registry.MustRegister(egressMetrics.NfConnctrackLimit)
 	metrics.Registry.MustRegister(egressMetrics.NfTableMasqueradeBytes)
 	metrics.Registry.MustRegister(egressMetrics.NfTableMasqueradePackets)
 	metrics.Registry.MustRegister(egressMetrics.NfTableInvalidBytes)

--- a/v2/cmd/coil-egress/sub/run.go
+++ b/v2/cmd/coil-egress/sub/run.go
@@ -78,7 +78,7 @@ func subMain() error {
 		}
 	}
 
-	protocols := make([]string, 0, 0)
+	protocols := make([]string, 0)
 	for protocol := range protocolMap {
 		protocols = append(protocols, protocol)
 	}

--- a/v2/cmd/coil-egress/sub/run.go
+++ b/v2/cmd/coil-egress/sub/run.go
@@ -37,8 +37,8 @@ func init() {
 
 	// +kubebuilder:scaffold:scheme
 
-	metrics.Registry.MustRegister(egressMetrics.NfConnctrackCount)
-	metrics.Registry.MustRegister(egressMetrics.NfConnctrackLimit)
+	metrics.Registry.MustRegister(egressMetrics.NfConntrackCount)
+	metrics.Registry.MustRegister(egressMetrics.NfConntrackLimit)
 	metrics.Registry.MustRegister(egressMetrics.NfTableMasqueradeBytes)
 	metrics.Registry.MustRegister(egressMetrics.NfTableMasqueradePackets)
 	metrics.Registry.MustRegister(egressMetrics.NfTableInvalidBytes)
@@ -71,10 +71,10 @@ func subMain() error {
 		}
 		if n4 := n.To4(); n4 != nil {
 			ipv4 = n4
-			protocolMap["ipv4"] = struct{}{}
+			protocolMap[constants.FamilyIPv4] = struct{}{}
 		} else {
 			ipv6 = n
-			protocolMap["ipv6"] = struct{}{}
+			protocolMap[constants.FamilyIPv6] = struct{}{}
 		}
 	}
 

--- a/v2/cmd/coil-egress/sub/run.go
+++ b/v2/cmd/coil-egress/sub/run.go
@@ -79,7 +79,7 @@ func subMain() error {
 	}
 
 	protocols := make([]string, 0, 0)
-	for protocol, _ := range protocolMap {
+	for protocol := range protocolMap {
 		protocols = append(protocols, protocol)
 	}
 

--- a/v2/pkg/constants/constants.go
+++ b/v2/pkg/constants/constants.go
@@ -90,3 +90,9 @@ const MetricsNS = "coil"
 const (
 	DefaultPool = "default"
 )
+
+// Layer 3 families
+const (
+	FamilyIPv4 = "ipv4"
+	FamilyIPv6 = "ipv6"
+)

--- a/v2/pkg/metrics/egress.go
+++ b/v2/pkg/metrics/egress.go
@@ -20,14 +20,14 @@ const (
 )
 
 var (
-	NfConnctackCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	NfConnctrackCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: constants.MetricsNS,
 		Subsystem: "egress",
 		Name:      "nf_conntrack_entries_count",
 		Help:      "the number of entries in the nf_conntrack table",
 	}, []string{"namespace", "pod", "egress"})
 
-	NfConnctackLimit = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	NfConnctrackLimit = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: constants.MetricsNS,
 		Subsystem: "egress",
 		Name:      "nf_conntrack_entries_limit",
@@ -64,10 +64,10 @@ var (
 )
 
 type egressCollector struct {
-	conn             *nftables.Conn
-	nfConnctackCount prometheus.Gauge
-	nfConnctackLimit prometheus.Gauge
-	perProtocol      map[string]*nfTablesPerProtocolMetrics
+	conn              *nftables.Conn
+	nfConnctrackCount prometheus.Gauge
+	nfConnctrackLimit prometheus.Gauge
+	perProtocol       map[string]*nfTablesPerProtocolMetrics
 }
 
 type nfTablesPerProtocolMetrics struct {
@@ -87,8 +87,8 @@ func newNfTablesPerProtocolMetrics(ns, pod, egress, protocol string) *nfTablesPe
 }
 
 func NewEgressCollector(ns, pod, egress string, protocols []string) (Collector, error) {
-	NfConnctackCount.Reset()
-	NfConnctackLimit.Reset()
+	NfConnctrackCount.Reset()
+	NfConnctrackLimit.Reset()
 	NfTableMasqueradeBytes.Reset()
 	NfTableMasqueradePackets.Reset()
 	NfTableInvalidPackets.Reset()
@@ -105,10 +105,10 @@ func NewEgressCollector(ns, pod, egress string, protocols []string) (Collector, 
 	}
 
 	return &egressCollector{
-		conn:             c,
-		nfConnctackCount: NfConnctackCount.WithLabelValues(ns, pod, egress),
-		nfConnctackLimit: NfConnctackLimit.WithLabelValues(ns, pod, egress),
-		perProtocol:      perProtocols,
+		conn:              c,
+		nfConnctrackCount: NfConnctrackCount.WithLabelValues(ns, pod, egress),
+		nfConnctrackLimit: NfConnctrackLimit.WithLabelValues(ns, pod, egress),
+		perProtocol:       perProtocols,
 	}, nil
 }
 
@@ -122,13 +122,13 @@ func (c *egressCollector) Update(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	c.nfConnctackCount.Set(float64(val))
+	c.nfConnctrackCount.Set(float64(val))
 
 	val, err = readUintFromFile(NF_CONNTRACK_LIMIT_PATH)
 	if err != nil {
 		return err
 	}
-	c.nfConnctackLimit.Set(float64(val))
+	c.nfConnctrackLimit.Set(float64(val))
 
 	for protocol, nfTablesMetrics := range c.perProtocol {
 		natPackets, natBytes, err := c.getNfTablesNATCounter(protocol)

--- a/v2/pkg/metrics/egress.go
+++ b/v2/pkg/metrics/egress.go
@@ -25,14 +25,14 @@ var (
 		Subsystem: "egress",
 		Name:      "nf_conntrack_entries_count",
 		Help:      "the number of entries in the nf_conntrack table",
-	}, []string{"namespace", "pod", "egress", "protocol"})
+	}, []string{"namespace", "pod", "egress"})
 
 	NfConnctackLimit = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: constants.MetricsNS,
 		Subsystem: "egress",
 		Name:      "nf_conntrack_entries_limit",
 		Help:      "the limit of the nf_conntrack table",
-	}, []string{"namespace", "pod", "egress", "protocol"})
+	}, []string{"namespace", "pod", "egress"})
 
 	NfTableMasqueradePackets = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: constants.MetricsNS,


### PR DESCRIPTION
This PR adds a IPv6 support for following egress related metrics.

- coil_egress_nftables_masqueraded_packets_total
- coil_egress_nftables_masqueraded_bytes_total
- coil_egress_nftables_invalid_packets_total
- coil_egress_nftables_invalid_bytes_total

I introduced a new label named `protocol` for these metrics, which can take `ipv4` or `ipv6`.

Signed-off-by: terashima <tomoya-terashima@cybozu.co.jp>
