### PR TITLE
Fix: flaky garbage collection tests by running GC immediately on start

### DIFF
--- a/v2/runners/garbage_collector.go
+++ b/v2/runners/garbage_collector.go
@@ -48,6 +48,10 @@ func (gc *garbageCollector) Start(ctx context.Context) error {
 	tick := time.NewTicker(gc.interval)
 	defer tick.Stop()
 
+	if err := gc.do(context.Background()); err != nil {
+		return err
+	}
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/v2/runners/garbage_collector.go
+++ b/v2/runners/garbage_collector.go
@@ -45,21 +45,18 @@ func (*garbageCollector) NeedLeaderElection() bool {
 
 // Start starts this runner.  This implements manager.Runnable
 func (gc *garbageCollector) Start(ctx context.Context) error {
-	tick := time.NewTicker(gc.interval)
-	defer tick.Stop()
-
-	if err := gc.do(context.Background()); err != nil {
-		return err
-	}
+	timer := time.NewTimer(0)
+	defer timer.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-tick.C:
+		case <-timer.C:
 			if err := gc.do(context.Background()); err != nil {
 				return err
 			}
+			timer.Reset(gc.interval)
 		}
 	}
 }


### PR DESCRIPTION
Execute garbage collection immediately on startup instead of waiting for first ticker interval.

Fixes #342