### PR TITLE
Removed leader election requirement for cert-controller's rotator

### DIFF
--- a/v2/pkg/cert/cert.go
+++ b/v2/pkg/cert/cert.go
@@ -39,7 +39,7 @@ func SetupRotator(mgr ctrl.Manager, objectType string, enableRestartOnCertRefres
 		DNSName:                fmt.Sprintf("%s.%s.svc", serviceName, podNamespace),
 		ExtraDNSNames:          []string{fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, podNamespace)},
 		IsReady:                setupFinished,
-		RequireLeaderElection:  true,
+		RequireLeaderElection:  false,
 		Webhooks:               webhooks,
 		RestartOnSecretRefresh: enableRestartOnCertRefresh,
 	}); err != nil {


### PR DESCRIPTION
Recently we found a bug in the implementation of cert-controller. It seems that with current config the cert rotator is only started after the leader election happens and leadership is obtained, therefore validating webhook service is not working properly as it points to the non operable endpoints, as only the leader is starting the webhook properly.

```bash
# list of the coil-egress-controller pods
patryk@dev ~ $ kubectl get pod -n kube-system -o wide | grep coil-egress
coil-egress-controller-678975b859-85mbm      1/1     Running             0          93s    172.18.0.3   coil-worker2         <none>           <none>
coil-egress-controller-678975b859-dfqv2      1/1     Running             0          93s    172.18.0.2   coil-worker          <none>           <none>
coil-egress-controller-678975b859-lpgmj      1/1     Running             0          93s    172.18.0.4   coil-control-plane   <none>           <none>
coil-egress-controller-678975b859-mwdm5      1/1     Running             0          93s    172.18.0.5   coil-worker3         <none>           <none>

# leader is coil-worker (172.18.0.2)
patryk@dev ~ $ kubectl get -n kube-system leases.coordination.k8s.io | grep coil-egress
coil-egress-leader                     coil-worker_69ef3c49-cadf-4e54-9779-d2dbe60b2438                            115s

# the leader is serving OK, replying with 404 for a simple curl request
patryk@dev ~ $ docker exec -it coil-control-plane curl -k https://172.18.0.2:9444
404 page not found

# other endpoints are broken
patryk@dev ~ $ docker exec -it coil-control-plane curl -k https://172.18.0.3:9444
curl: (7) Failed to connect to 172.18.0.3 port 9444 after 0 ms: Couldn't connect to server

patryk@dev ~ $ docker exec -it coil-control-plane curl -k https://172.18.0.4:9444
curl: (7) Failed to connect to 172.18.0.4 port 9444 after 0 ms: Couldn't connect to server

patryk@dev ~ $ docker exec -it coil-control-plane curl -k https://172.18.0.5:9444
curl: (7) Failed to connect to 172.18.0.5 port 9444 after 0 ms: Couldn't connect to server

```

After this fix:

```bash
patryk@dev ~ $ kubectl get pod -n kube-system -o wide | grep coil-egress
coil-egress-controller-678975b859-f2pxk      1/1     Running             0            10s   172.18.0.5   coil-worker2         <none>           <none>
coil-egress-controller-678975b859-kt2br      1/1     Running             0            10s   172.18.0.4   coil-worker3         <none>           <none>
coil-egress-controller-678975b859-s5ddr      1/1     Running             0            10s   172.18.0.2   coil-worker          <none>           <none>
coil-egress-controller-678975b859-shjmc      1/1     Running             0            10s   172.18.0.3   coil-control-plane   <none>           <none>

# leader is coil-worker (172.18.0.2)
patryk@dev ~ $ kubectl get -n kube-system leases.coordination.k8s.io | grep coil-egress
coil-egress-leader                     coil-worker_9cbcf7af-2bc6-47bb-b1b0-0effe7f36745                            20s

# we can connect to all the endpoints now
patryk@dev ~ $ docker exec -it coil-control-plane curl -k https://172.18.0.2:9444
404 page not found

patryk@dev ~ $ docker exec -it coil-control-plane curl -k https://172.18.0.3:9444
404 page not found

patryk@dev ~ $ docker exec -it coil-control-plane curl -k https://172.18.0.4:9444
404 page not found

patryk@dev ~ $ docker exec -it coil-control-plane curl -k https://172.18.0.5:9444
404 page not found

```