### PR TITLE
coild: clear export routes when node is deleted

### DIFF
--- a/v2/cmd/coild/sub/run.go
+++ b/v2/cmd/coild/sub/run.go
@@ -135,7 +135,7 @@ func subMain() error {
 	if err != nil {
 		return err
 	}
-	server := runners.NewCoildServer(l, mgr, nodeIPAM, podNet, runners.NewNATSetup(cfg.EgressPort), cfg, grpcLogger, runners.ProcessLinkAlias)
+	server := runners.NewCoildServer(l, mgr, nodeIPAM, podNet, runners.NewNATSetup(cfg.EgressPort), cfg, grpcLogger, runners.ProcessLinkAlias, nodeName)
 	if err := mgr.Add(server); err != nil {
 		return err
 	}

--- a/v2/config/pod/coild.yaml
+++ b/v2/config/pod/coild.yaml
@@ -23,7 +23,7 @@ spec:
       - effect: NoExecute
         operator: Exists
       serviceAccountName: coild
-      terminationGracePeriodSeconds: 1
+      terminationGracePeriodSeconds: 30
       containers:
       - name: coild
         image: coil:dev

--- a/v2/controllers/mock_test.go
+++ b/v2/controllers/mock_test.go
@@ -139,6 +139,10 @@ func (n *mockNodeIPAM) NodeInternalIP(ctx context.Context) (net.IP, net.IP, erro
 	panic("not implemented")
 }
 
+func (n *mockNodeIPAM) ClearRoutes(ctx context.Context) error {
+	panic("not implemented")
+}
+
 type mockFoUTunnel struct {
 	mu    sync.Mutex
 	peers map[string]bool

--- a/v2/e2e/coil_test.go
+++ b/v2/e2e/coil_test.go
@@ -173,29 +173,32 @@ func testIPAM() {
 
 	It("should persist IPAM status between coild restarts", func() {
 		By("removing coild pods")
+		oldPods := &corev1.PodList{}
+		getResourceSafe("kube-system", "pods", "", "app.kubernetes.io/component=coild", oldPods)
+		oldUIDs := make(map[string]struct{})
+		for _, pod := range oldPods.Items {
+			oldUIDs[string(pod.UID)] = struct{}{}
+		}
 		kubectlSafe(nil, "-n", "kube-system", "delete", "pods", "-l", "app.kubernetes.io/component=coild")
 		Eventually(func() error {
 			ds := &appsv1.DaemonSet{}
-			err := getResource("kube-system", "daemonsets", "coild", "", ds)
-			if err != nil {
-				return err
-			}
-			if ds.Status.NumberReady == 4 {
-				return errors.New("not yet deleted")
-			}
-			return nil
-		}).Should(Succeed())
-		Eventually(func() error {
-			ds := &appsv1.DaemonSet{}
-			err := getResource("kube-system", "daemonsets", "coild", "", ds)
-			if err != nil {
+			if err := getResource("kube-system", "daemonsets", "coild", "", ds); err != nil {
 				return err
 			}
 			if ds.Status.NumberReady != 4 {
 				return errors.New("not yet recreated")
 			}
+			newPods := &corev1.PodList{}
+			if err := getResource("kube-system", "pods", "", "app.kubernetes.io/component=coild", newPods); err != nil {
+				return err
+			}
+			for _, pod := range newPods.Items {
+				if _, old := oldUIDs[string(pod.UID)]; old {
+					return errors.New("old pod still present")
+				}
+			}
 			return nil
-		})
+		}).Should(Succeed())
 
 		By("checking AddressBlock")
 		// This needs to be Eventually because sometimes coild has extra AddressBlock.

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	AddressBlockGCInterval time.Duration
 	Backend                string
 	OriginatingOnly        bool
+	ClearRoutesOnShutdown  bool
 }
 
 func Parse(rootCmd *cobra.Command) *Config {
@@ -48,6 +49,7 @@ func Parse(rootCmd *cobra.Command) *Config {
 	pf.DurationVar(&config.AddressBlockGCInterval, "addressblock-gc-interval", constants.DefaultAddressBlockGCInterval, "interval for address block GC")
 	pf.StringVar(&config.Backend, "backend", constants.DefaultEgressBackend, "backend for egress NAT rules: iptables or nftables (default: iptables)")
 	pf.BoolVar(&config.OriginatingOnly, "enable-originating-only", constants.DefaultOriginatingOnly, "egress should be used only for connections originating in the pod (default: false)")
+	pf.BoolVar(&config.ClearRoutesOnShutdown, "clear-routes-on-shutdown", constants.DefaultClearRoutesOnShutdown, "clear export routes when the node is deleted")
 
 	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(goflags)

--- a/v2/pkg/constants/constants.go
+++ b/v2/pkg/constants/constants.go
@@ -108,3 +108,6 @@ const DefaultEgressBackend = EgressBackendIPTables
 
 // Default originating only
 const DefaultOriginatingOnly = false
+
+// DefaultClearRoutesOnShutdown is the default value for clearing export routes on node deletion
+const DefaultClearRoutesOnShutdown = false

--- a/v2/pkg/ipam/node.go
+++ b/v2/pkg/ipam/node.go
@@ -70,6 +70,10 @@ type NodeIPAM interface {
 
 	// NodeInternalIP returns node's internal IP addresses
 	NodeInternalIP(ctx context.Context) (ipv4, ipv6 net.IP, err error)
+
+	// ClearRoutes removes all exported routes from the kernel routing table.
+	// This should be called when the node is being deleted to stop BGP advertisement.
+	ClearRoutes(ctx context.Context) error
 }
 
 // +kubebuilder:rbac:groups=coil.cybozu.com,resources=addressblocks,verbs=get;list;update;patch;delete
@@ -106,6 +110,13 @@ func NewNodeIPAM(nodeName string, l logr.Logger, mgr manager.Manager, exporter n
 		exporter:  exporter,
 		pools:     make(map[string]*nodePool),
 	}
+}
+
+func (n *nodeIPAM) ClearRoutes(ctx context.Context) error {
+	if n.exporter == nil {
+		return nil
+	}
+	return n.exporter.Sync(nil)
 }
 
 func (n *nodeIPAM) sync(ctx context.Context) error {

--- a/v2/pkg/ipam/node_test.go
+++ b/v2/pkg/ipam/node_test.go
@@ -356,6 +356,23 @@ var _ = Describe("NodeIPAM", func() {
 		Expect(ipv4).To(BeNil())
 		Expect(ipv6).To(EqualIP(net.ParseIP("fd10::43")))
 	})
+
+	It("should clear export routes when exporter is set", func() {
+		e := &mockExporter{}
+		_, ipnet, err := net.ParseCIDR("10.2.0.0/24")
+		Expect(err).ToNot(HaveOccurred())
+		e.Sync([]*net.IPNet{ipnet})
+		Expect(e.Equal([]string{"10.2.0.0/24"})).To(BeTrue())
+
+		nodeIPAM := NewNodeIPAM("node1", ctrl.Log.WithName("NodeIPAM-clear"), mgr, e)
+		Expect(nodeIPAM.ClearRoutes(ctx)).To(Succeed())
+		Expect(e.Equal([]string{})).To(BeTrue())
+	})
+
+	It("should do nothing when exporter is nil", func() {
+		nodeIPAM := NewNodeIPAM("node1", ctrl.Log.WithName("NodeIPAM-clear-nil"), mgr, nil)
+		Expect(nodeIPAM.ClearRoutes(ctx)).To(Succeed())
+	})
 })
 
 type equalIP struct {

--- a/v2/runners/coild_server.go
+++ b/v2/runners/coild_server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
@@ -161,8 +162,14 @@ func (s *coildServer) Start(ctx context.Context) error {
 	// see https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md
 	reflection.Register(grpcServer)
 
+	var gcWg sync.WaitGroup
 	go func() {
 		<-ctx.Done()
+		grpcServer.GracefulStop()
+		if !s.cfg.ClearRoutesOnShutdown {
+			return
+		}
+		gcWg.Wait()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), nodeDeletedCleanupTimeout)
 		defer cancel()
 		node := &corev1.Node{}
@@ -172,20 +179,26 @@ func (s *coildServer) Start(ctx context.Context) error {
 			if err := s.nodeIPAM.ClearRoutes(shutdownCtx); err != nil {
 				s.logger.Sugar().Errorw("failed to clear export routes on node deletion", "error", err)
 			}
+		} else if err != nil {
+			s.logger.Sugar().Warnw("failed to get node on shutdown, skipping route cleanup", "error", err)
 		}
-		grpcServer.GracefulStop()
 	}()
 
 	s.logger.Info("start periodic nodeIPAM GC")
 	gcTicker := time.NewTicker(s.cfg.AddressBlockGCInterval)
 	go func(ctx context.Context) {
 		for {
-			<-gcTicker.C
+			select {
+			case <-ctx.Done():
+				return
+			case <-gcTicker.C:
+			}
+			gcWg.Add(1)
 			if err := s.nodeIPAM.GC(ctx); err != nil {
 				s.logger.Sugar().Error("failed to run GC", "error", err)
 			}
+			gcWg.Done()
 		}
-
 	}(ctx)
 
 	return grpcServer.Serve(s.listener)

--- a/v2/runners/coild_server.go
+++ b/v2/runners/coild_server.go
@@ -96,7 +96,7 @@ func (n natSetup) Hook(l []GWNets, backend string, log *zap.Logger) func(ipv4, i
 
 // NewCoildServer returns an implementation of cnirpc.CNIServer for coild.
 func NewCoildServer(l net.Listener, mgr manager.Manager, nodeIPAM ipam.NodeIPAM, podNet nodenet.PodNetwork, setup NATSetup, cfg *config.Config, logger *zap.Logger,
-	aliasFunc func(conf *nodenet.PodNetConf, pod *corev1.Pod, ifName string) error) manager.Runnable {
+	aliasFunc func(conf *nodenet.PodNetConf, pod *corev1.Pod, ifName string) error, nodeName string) manager.Runnable {
 	return &coildServer{
 		listener:  l,
 		apiReader: mgr.GetAPIReader(),
@@ -107,12 +107,15 @@ func NewCoildServer(l net.Listener, mgr manager.Manager, nodeIPAM ipam.NodeIPAM,
 		logger:    logger,
 		cfg:       cfg,
 		aliasFunc: aliasFunc,
+		nodeName:  nodeName,
 	}
 }
 
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get
 // +kubebuilder:rbac:groups="",resources=namespaces;services,verbs=get;list;watch
 // +kubebuilder:rbac:groups=coil.cybozu.com,resources=egresses,verbs=get;list;watch
+
+const nodeDeletedCleanupTimeout = 10 * time.Second
 
 var grpcMetrics = grpc_prometheus.NewServerMetrics()
 
@@ -132,6 +135,7 @@ type coildServer struct {
 	logger    *zap.Logger
 	cfg       *config.Config
 	aliasFunc func(conf *nodenet.PodNetConf, pod *corev1.Pod, ifName string) error
+	nodeName  string
 }
 
 var _ manager.LeaderElectionRunnable = &coildServer{}
@@ -159,6 +163,16 @@ func (s *coildServer) Start(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), nodeDeletedCleanupTimeout)
+		defer cancel()
+		node := &corev1.Node{}
+		err := s.apiReader.Get(shutdownCtx, client.ObjectKey{Name: s.nodeName}, node)
+		if apierrors.IsNotFound(err) {
+			s.logger.Info("node is deleted, clearing export routes")
+			if err := s.nodeIPAM.ClearRoutes(shutdownCtx); err != nil {
+				s.logger.Sugar().Errorw("failed to clear export routes on node deletion", "error", err)
+			}
+		}
 		grpcServer.GracefulStop()
 	}()
 

--- a/v2/runners/coild_server.go
+++ b/v2/runners/coild_server.go
@@ -163,6 +163,21 @@ func (s *coildServer) Start(ctx context.Context) error {
 	reflection.Register(grpcServer)
 
 	var gcWg sync.WaitGroup
+	s.logger.Info("start periodic nodeIPAM GC")
+	gcTicker := time.NewTicker(s.cfg.AddressBlockGCInterval)
+	gcWg.Go(func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-gcTicker.C:
+				if err := s.nodeIPAM.GC(ctx); err != nil {
+					s.logger.Sugar().Error("failed to run GC", "error", err)
+				}
+			}
+		}
+	})
+
 	go func() {
 		<-ctx.Done()
 		grpcServer.GracefulStop()
@@ -183,23 +198,6 @@ func (s *coildServer) Start(ctx context.Context) error {
 			s.logger.Sugar().Warnw("failed to get node on shutdown, skipping route cleanup", "error", err)
 		}
 	}()
-
-	s.logger.Info("start periodic nodeIPAM GC")
-	gcTicker := time.NewTicker(s.cfg.AddressBlockGCInterval)
-	go func(ctx context.Context) {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-gcTicker.C:
-			}
-			gcWg.Add(1)
-			if err := s.nodeIPAM.GC(ctx); err != nil {
-				s.logger.Sugar().Error("failed to run GC", "error", err)
-			}
-			gcWg.Done()
-		}
-	}(ctx)
 
 	return grpcServer.Serve(s.listener)
 }

--- a/v2/runners/coild_server_test.go
+++ b/v2/runners/coild_server_test.go
@@ -59,6 +59,9 @@ func (n *mockNodeIPAM) Notify(*coilv2.BlockRequest) {
 func (n *mockNodeIPAM) NodeInternalIP(ctx context.Context) (net.IP, net.IP, error) {
 	panic("not implemented")
 }
+func (n *mockNodeIPAM) ClearRoutes(ctx context.Context) error {
+	return nil
+}
 
 func (n *mockNodeIPAM) Allocate(ctx context.Context, poolName, containerID, iface string) (ipv4, ipv6 net.IP, err error) {
 	n.nAllocate++
@@ -242,7 +245,7 @@ var _ = Describe("Coild server", func() {
 			AddressBlockGCInterval: 10 * time.Second,
 		}
 
-		serv := NewCoildServer(l, mgr, nodeIPAM, podNet, natsetup, cfg, logger, mockAlias)
+		serv := NewCoildServer(l, mgr, nodeIPAM, podNet, natsetup, cfg, logger, mockAlias, "test-node")
 		err = mgr.Add(serv)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/v2/runners/coild_server_test.go
+++ b/v2/runners/coild_server_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync/atomic"
 	"time"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
@@ -42,9 +43,10 @@ const (
 )
 
 type mockNodeIPAM struct {
-	nAllocate int
-	nFree     int
-	errFree   bool
+	nAllocate    int
+	nFree        int
+	errFree      bool
+	nClearRoutes atomic.Int32
 }
 
 func (n *mockNodeIPAM) Register(ctx context.Context, poolName, containerID, iface string, ipv4, ipv6 net.IP) error {
@@ -60,6 +62,7 @@ func (n *mockNodeIPAM) NodeInternalIP(ctx context.Context) (net.IP, net.IP, erro
 	panic("not implemented")
 }
 func (n *mockNodeIPAM) ClearRoutes(ctx context.Context) error {
+	n.nClearRoutes.Add(1)
 	return nil
 }
 
@@ -578,4 +581,85 @@ var _ = Describe("Coild server", func() {
 			Expect(subnet.IP.Equal(net.ParseIP("192.168.0.0"))).To(BeTrue())
 		})
 	}
+})
+
+var _ = Describe("shutdown route cleanup", func() {
+	var nodeIPAM *mockNodeIPAM
+	var mgrDone chan struct{}
+	var cancel context.CancelFunc
+	var socketPath string
+
+	BeforeEach(func() {
+		// Initialize with safe defaults so AfterEach does not crash if startServer is never called.
+		cancel = func() {}
+		mgrDone = make(chan struct{})
+		close(mgrDone)
+	})
+
+	AfterEach(func() {
+		cancel()
+		Eventually(mgrDone, "15s").Should(BeClosed())
+		os.Remove(socketPath)
+	})
+
+	startServer := func(nodeName string, clearRoutes bool) {
+		tmpFile, err := os.CreateTemp("", "")
+		Expect(err).ToNot(HaveOccurred())
+		socketPath = tmpFile.Name()
+		tmpFile.Close()
+		os.Remove(socketPath)
+
+		var ctx context.Context
+		ctx, cancel = context.WithCancel(context.Background())
+
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:         scheme,
+			LeaderElection: false,
+			Metrics: metricsserver.Options{
+				BindAddress: "0",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		l, err := net.Listen("unix", socketPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		nodeIPAM = &mockNodeIPAM{}
+		logger := zap.NewRaw(zap.StacktraceLevel(zapcore.DPanicLevel))
+		servCfg := &config.Config{
+			AddressBlockGCInterval: 1 * time.Hour,
+			ClearRoutesOnShutdown:  clearRoutes,
+		}
+
+		serv := NewCoildServer(l, mgr, nodeIPAM, &mockPodNetwork{}, &mockNATSetup{}, servCfg, logger, mockAlias, nodeName)
+		err = mgr.Add(serv)
+		Expect(err).ToNot(HaveOccurred())
+
+		mgrDone = make(chan struct{})
+		go func() {
+			defer close(mgrDone)
+			_ = mgr.Start(ctx)
+		}()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	It("clears routes when node does not exist and flag is enabled", func() {
+		startServer("nonexistent-node", true)
+		cancel()
+		Eventually(func() int32 { return nodeIPAM.nClearRoutes.Load() }, "5s").Should(Equal(int32(1)))
+	})
+
+	It("does not clear routes when node exists and flag is enabled", func() {
+		startServer("node1", true)
+		cancel()
+		Eventually(mgrDone, "5s").Should(BeClosed())
+		Consistently(func() int32 { return nodeIPAM.nClearRoutes.Load() }, "200ms").Should(Equal(int32(0)))
+	})
+
+	It("does not clear routes when flag is disabled", func() {
+		startServer("nonexistent-node", false)
+		cancel()
+		Eventually(mgrDone, "5s").Should(BeClosed())
+		Consistently(func() int32 { return nodeIPAM.nClearRoutes.Load() }, "200ms").Should(Equal(int32(0)))
+	})
 })


### PR DESCRIPTION
When a node is deleted from Kubernetes, coild is terminated by the
Pod GC Controller ~40-60s later. At that point, the export routing
table (table 119) still contains routes, causing routing daemons
(e.g. BIRD, FRR) to continue BGP advertisement for the deleted
node's PodCIDRs.

On shutdown, coild now checks whether its node object has been
deleted. If so, it clears all routes from the export table before
exiting, stopping BGP advertisement from routing daemons.

Also increase terminationGracePeriodSeconds from 1 to 30 to allow
the cleanup to complete reliably.

Signed-off-by: naoki-take <naoki-take@cybozu.co.jp>