### PR TITLE
Refactor CI e2e

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,11 @@ defaults:
 env:
   go-version: "1.26.3"
   cache-version: 1
+  # Supported Kubernetes versions. Bump these three values when adding/dropping
+  # versions; all matrix entries below reference the YAML anchors.
+  K8S_LATEST: &k8s-latest "1.35.1"
+  K8S_PREV1:  &k8s-prev1  "1.34.3"
+  K8S_PREV2:  &k8s-prev2  "1.33.7"
 jobs:
   test:
     name: Small test
@@ -42,28 +47,55 @@ jobs:
     - run: make test-integration
     - run: make check-generate
   e2e:
-    name: End-to-end Test
+    name: e2e ${{ matrix.kindest-node }} ${{ matrix.label }}
+    needs: test
     strategy:
+      fail-fast: false
+      # Sparse matrix: K8S_LATEST covers representative scenarios;
+      # K8S_PREV1 / K8S_PREV2 only run a small set of API compatibility
+      # checks. originatingonly=true is exercised once per mode because
+      # its branch (v2/e2e/coil_test.go) is orthogonal to IP family and
+      # backend.
       matrix:
-        kindest-node: ["1.33.7", "1.34.3", "1.35.1"]
-        with-ipam: ["false", "true"]
-        ipv4: ["false", "true"]
-        ipv6: ["false", "true"]
-        ipv6-primary: ["false", "true"]
-        backend: ["iptables", "nftables"]
-        originatingonly: ["false", "true"]
-        exclude:
-        - ipv4: "false"
-          ipv6: "false"
-        - ipv4: "false"
-          ipv6: "true"
-          ipv6-primary: "true"
-        - ipv4: "true"
-          ipv6: "false"
-          ipv6-primary: "true"
-        - with-ipam: "true"
-          backend: "nftables"
+        include:
+        # K8S_LATEST: 15 scenarios
+        # Group A: IPAM mode (with-ipam=true, backend=iptables)
+        - { kindest-node: *k8s-latest, with-ipam: "true",  ipv4: "true",  ipv6: "false", ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "ipam v4" }
+        - { kindest-node: *k8s-latest, with-ipam: "true",  ipv4: "false", ipv6: "true",  ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "ipam v6" }
+        - { kindest-node: *k8s-latest, with-ipam: "true",  ipv4: "true",  ipv6: "true",  ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "ipam dual" }
+        - { kindest-node: *k8s-latest, with-ipam: "true",  ipv4: "true",  ipv6: "true",  ipv6-primary: "true",  backend: "iptables", originatingonly: "false", label: "ipam dual-v6p" }
+        - { kindest-node: *k8s-latest, with-ipam: "true",  ipv4: "true",  ipv6: "false", ipv6-primary: "false", backend: "iptables", originatingonly: "true",  label: "ipam v4 orig-only" }
+        # Group B: standalone egress with iptables backend
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "true",  ipv6: "false", ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "egress v4 iptables" }
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "false", ipv6: "true",  ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "egress v6 iptables" }
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "true",  ipv6: "true",  ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "egress dual iptables" }
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "true",  ipv6: "true",  ipv6-primary: "true",  backend: "iptables", originatingonly: "false", label: "egress dual-v6p iptables" }
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "true",  ipv6: "true",  ipv6-primary: "true",  backend: "iptables", originatingonly: "true",  label: "egress dual-v6p iptables orig-only" }
+        # Group C: standalone egress with nftables backend
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "true",  ipv6: "false", ipv6-primary: "false", backend: "nftables", originatingonly: "false", label: "egress v4 nftables" }
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "false", ipv6: "true",  ipv6-primary: "false", backend: "nftables", originatingonly: "false", label: "egress v6 nftables" }
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "true",  ipv6: "true",  ipv6-primary: "false", backend: "nftables", originatingonly: "false", label: "egress dual nftables" }
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "true",  ipv6: "true",  ipv6-primary: "true",  backend: "nftables", originatingonly: "false", label: "egress dual-v6p nftables" }
+        - { kindest-node: *k8s-latest, with-ipam: "false", ipv4: "true",  ipv6: "false", ipv6-primary: "false", backend: "nftables", originatingonly: "true",  label: "egress v4 nftables orig-only" }
+        # K8S_PREV1: 4 representative scenarios
+        - { kindest-node: *k8s-prev1,  with-ipam: "true",  ipv4: "true", ipv6: "false", ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "ipam v4" }
+        - { kindest-node: *k8s-prev1,  with-ipam: "true",  ipv4: "true", ipv6: "true",  ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "ipam dual" }
+        - { kindest-node: *k8s-prev1,  with-ipam: "false", ipv4: "true", ipv6: "false", ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "egress v4 iptables" }
+        - { kindest-node: *k8s-prev1,  with-ipam: "false", ipv4: "true", ipv6: "false", ipv6-primary: "false", backend: "nftables", originatingonly: "false", label: "egress v4 nftables" }
+        # K8S_PREV2: 4 representative scenarios
+        - { kindest-node: *k8s-prev2, with-ipam: "true",  ipv4: "true", ipv6: "false", ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "ipam v4" }
+        - { kindest-node: *k8s-prev2, with-ipam: "true",  ipv4: "true", ipv6: "true",  ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "ipam dual" }
+        - { kindest-node: *k8s-prev2, with-ipam: "false", ipv4: "true", ipv6: "false", ipv6-primary: "false", backend: "iptables", originatingonly: "false", label: "egress v4 iptables" }
+        - { kindest-node: *k8s-prev2, with-ipam: "false", ipv4: "true", ipv6: "false", ipv6-primary: "false", backend: "nftables", originatingonly: "false", label: "egress v4 nftables" }
     runs-on: ubuntu-24.04
+    env:
+      KUBERNETES_VERSION: ${{ matrix.kindest-node }}
+      WITH_IPAM:          ${{ matrix.with-ipam }}
+      TEST_IPV4:          ${{ matrix.ipv4 }}
+      TEST_IPV6:          ${{ matrix.ipv6 }}
+      IPV6_PRIMARY:       ${{ matrix.ipv6-primary }}
+      BACKEND:            ${{ matrix.backend }}
+      ORIGINATINGONLY:    ${{ matrix.originatingonly }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -72,64 +104,13 @@ jobs:
         cache-dependency-path: "**/go.sum"
     - run: make image
     - run: make certs
-    - name: Enable docker IPv6 mode
-      if: matrix.ipv6 == 'true'
+    - run: make ci-enable-docker-ipv6
       working-directory: v2/e2e
-      run: |
-        sudo mkdir -p /etc/docker
-        sudo cp daemon.json /etc/docker/daemon.json
-        sudo systemctl restart docker.service
-        sleep 10
-        echo TEST_IPV6=true >> $GITHUB_ENV
-    - run: make start KUBERNETES_VERSION=${{ matrix.kindest-node }} WITH_KINDNET=false TEST_IPV4=${{ matrix.ipv4 }} TEST_IPV6=${{ matrix.ipv6 }} IPV6_PRIMARY=${{ matrix.ipv6-primary }}
-      if: matrix.with-ipam == 'true'
-      working-directory: v2/e2e
-    - run: make start KUBERNETES_VERSION=${{ matrix.kindest-node }} WITH_KINDNET=true TEST_IPV4=${{ matrix.ipv4 }} TEST_IPV6=${{ matrix.ipv6 }} IPV6_PRIMARY=${{ matrix.ipv6-primary }}
-      if: matrix.with-ipam == 'false'
+    - run: make start
       working-directory: v2/e2e
     - run: make install-coil
-      if: matrix.with-ipam == 'true' && matrix.originatingonly == 'false'
       working-directory: v2/e2e
-    - run: make install-coil-originatingonly
-      if: matrix.with-ipam == 'true' && matrix.originatingonly == 'true'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-v4
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'true' && matrix.ipv6 == 'false' && matrix.backend == 'iptables' && matrix.originatingonly == 'false'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-v4-nft
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'true' && matrix.ipv6 == 'false' && matrix.backend == 'nftables' && matrix.originatingonly == 'false'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-v6
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'false' && matrix.ipv6 == 'true' && matrix.backend == 'iptables' && matrix.originatingonly == 'false'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-v6-nft
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'false' && matrix.ipv6 == 'true' && matrix.backend == 'nftables' && matrix.originatingonly == 'false'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-dualstack
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'true' && matrix.ipv6 == 'true' && matrix.backend == 'iptables' && matrix.originatingonly == 'false'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-dualstack-nft
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'true' && matrix.ipv6 == 'true' && matrix.backend == 'nftables' && matrix.originatingonly == 'false'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-v4-originatingonly
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'true' && matrix.ipv6 == 'false' && matrix.backend == 'iptables' && matrix.originatingonly == 'true'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-v4-nft-originatingonly
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'true' && matrix.ipv6 == 'false' && matrix.backend == 'nftables' && matrix.originatingonly == 'true'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-v6-originatingonly
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'false' && matrix.ipv6 == 'true' && matrix.backend == 'iptables' && matrix.originatingonly == 'true'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-v6-nft-originatingonly
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'false' && matrix.ipv6 == 'true' && matrix.backend == 'nftables' && matrix.originatingonly == 'true'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-dualstack-originatingonly
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'true' && matrix.ipv6 == 'true' && matrix.backend == 'iptables' && matrix.originatingonly == 'true'
-      working-directory: v2/e2e
-    - run: make install-coil-egress-dualstack-nft-originatingonly
-      if: matrix.with-ipam == 'false' && matrix.ipv4 == 'true' && matrix.ipv6 == 'true' && matrix.backend == 'nftables' && matrix.originatingonly == 'true'
-      working-directory: v2/e2e
-    - run: make test TEST_IPAM=${{ matrix.with-ipam }} TEST_EGRESS=true TEST_IPV4=${{ matrix.ipv4 }} TEST_IPV6=${{ matrix.ipv6 }} TEST_ORIGINATINGONLY=${{ matrix.originatingonly }}
+    - run: make test
       working-directory: v2/e2e
     - run: make logs
       working-directory: v2/e2e
@@ -137,13 +118,15 @@ jobs:
     - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       if: always()
       with:
-        name: logs-ipv4-${{ matrix.ipv4 }}-ipv6-${{ matrix.ipv6 }}-with-ipam-${{ matrix.with-ipam }}-ipv6-primary-${{ matrix.ipv6-primary }}-backend-${{ matrix.backend }}-${{ matrix.originatingonly }}-${{ matrix.kindest-node }}.tar.gz
+        name: logs-${{ matrix.kindest-node }}-ipam${{ matrix.with-ipam }}-v4${{ matrix.ipv4 }}-v6${{ matrix.ipv6 }}-v6p${{ matrix.ipv6-primary }}-${{ matrix.backend }}-oo${{ matrix.originatingonly }}.tar.gz
         path: v2/e2e/logs.tar.gz
   certs-generation:
     name: Cert generation test
+    needs: test
     strategy:
+      fail-fast: false
       matrix:
-        kindest-node: ["1.33.7", "1.34.3", "1.35.1"]
+        kindest-node: [*k8s-prev2, *k8s-prev1, *k8s-latest]
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -301,17 +301,21 @@ To deploy Coil with only egress feature enabled the following changes are requir
     ```bash
     cd e2e
     ```
+1. Export the scenario environment (egress-only IPv4):
+    ```bash
+    export WITH_IPAM=false TEST_IPV4=true TEST_IPV6=false
+    ```
 1. Create IPv4 based Kind cluster with Kindnet CNI deployed:
     ```bash
-    WITH_KINDNET=true TEST_IPV6=false make start
+    make start
     ```
 1. Install Coil on the cluster:
     ```bash
-    make install-coil-egress-v4
+    make install-coil
     ```
 1. Run egress-only IPv4 tests:
     ```bash
-    TEST_IPAM=false TEST_EGRESS=true TEST_IPV6=false make test
+    make test
     ```
 
 #### Testing with Kindnet using IPv6
@@ -323,15 +327,19 @@ To deploy Coil with only egress feature enabled the following changes are requir
     ```bash
     cd e2e
     ```
+1. Export the scenario environment (egress-only IPv6):
+    ```bash
+    export WITH_IPAM=false TEST_IPV4=false TEST_IPV6=true
+    ```
 1. Create IPv6 based Kind cluster with Kindnet CNI deployed:
     ```bash
-    WITH_KINDNET=true TEST_IPV6=true make start
+    make start
     ```
 1. Install Coil on the cluster:
     ```bash
-    make install-coil-egress-v6
+    make install-coil
     ```
 1. Run egress-only IPv6 tests:
     ```bash
-    TEST_IPAM=false TEST_EGRESS=true TEST_IPV6=true make test
+    make test
     ```

--- a/v2/e2e/Makefile
+++ b/v2/e2e/Makefile
@@ -1,5 +1,5 @@
 KIND_VERSION=0.31.0
-KUBERNETES_VERSION=1.35.1
+KUBERNETES_VERSION ?= 1.35.1
 KUSTOMIZE_VERSION = 5.8.1
 BINDIR := $(abspath $(PWD)/../bin)
 
@@ -9,6 +9,17 @@ KIND := $(BINDIR)/kind
 KUBECTL := $(BINDIR)/kubectl
 KUSTOMIZE := $(BINDIR)/kustomize
 export KUBECTL
+
+# E2E scenario inputs (override via environment or `make X=Y`).
+WITH_IPAM ?= true
+TEST_IPV4 ?= true
+TEST_IPV6 ?= false
+IPV6_PRIMARY ?= false
+BACKEND ?= iptables
+ORIGINATINGONLY ?= false
+TEST_EGRESS ?= true
+# IPAM mode uses coil as the CNI; egress-only mode keeps kindnet as the CNI.
+WITH_KINDNET ?= $(if $(filter true,$(WITH_IPAM)),false,true)
 
 KIND_CONFIG = kind-config.yaml
 ifeq ($(TEST_IPV6),true)
@@ -39,7 +50,7 @@ else
 	endif
 endif
 
-TIMEOUT=0
+TIMEOUT = 0
 
 .PHONY: start
 start: $(KIND) $(KUBECTL) $(KUSTOMIZE)
@@ -49,207 +60,59 @@ start: $(KIND) $(KUBECTL) $(KUSTOMIZE)
 stop: $(KIND)
 	$(KIND) delete cluster --name coil
 
+# Egress mode kustomize overlay selection.
+EGRESS_PROTO := $(if $(filter true,$(TEST_IPV4)),$(if $(filter true,$(TEST_IPV6)),dualstack,v4),v6)
+EGRESS_NFT_SUFFIX := $(if $(filter nftables,$(BACKEND)),-nft,)
+EGRESS_OO_SUFFIX := $(if $(filter true,$(ORIGINATINGONLY)),-originatingonly,)
+
+# Protocols passed to kindnet-configurer (only used in egress mode).
+KINDNET_PROTOS := $(strip \
+  $(if $(filter true,$(TEST_IPV4)),v4,) \
+  $(if $(filter true,$(TEST_IPV6)),v6,))
+
+ifeq ($(WITH_IPAM),true)
+  KUSTOMIZE_DIR := $(if $(filter true,$(ORIGINATINGONLY)),configs/originatingonly,.)
+else
+  KUSTOMIZE_DIR := configs/egress/$(EGRESS_PROTO)$(EGRESS_NFT_SUFFIX)$(EGRESS_OO_SUFFIX)
+endif
+
+# Unified install target. Behavior depends on WITH_IPAM:
+#   true  -> coil acts as the CNI; deploy IPAM + egress controllers.
+#   false -> coil runs as standalone egress; rewrite kindnet's CNI config to
+#            chain coil after kindnet, then deploy egress controllers + coild.
 .PHONY: install-coil
 install-coil: setup-nodes
 	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone . | $(KUBECTL) apply -f -
+ifeq ($(WITH_IPAM),false)
+	@if [ -z "$(strip $(KINDNET_PROTOS))" ]; then \
+		echo "ERROR: WITH_IPAM=false requires TEST_IPV4=true and/or TEST_IPV6=true"; \
+		exit 1; \
+	fi
+	rm -rf tmp && mkdir tmp 2> /dev/null
+	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
+	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
+	$(foreach p,$(KINDNET_PROTOS),./kindnet-conf --action get --protocol $(p) &&) :
+endif
+	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone $(KUSTOMIZE_DIR) | $(KUBECTL) apply -f -
+ifeq ($(WITH_IPAM),true)
 	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-ipam-controller
+endif
 	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-
-.PHONY: install-coil-originatingonly
-install-coil-originatingonly: setup-nodes
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/originatingonly  | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-ipam-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-
-.PHONY: install-coil-egress-v4
-install-coil-egress-v4: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	./kindnet-conf --action get
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/v4 | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
+ifeq ($(WITH_IPAM),false)
 	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist
+	$(foreach p,$(KINDNET_PROTOS),./kindnet-conf --action set --cni-config 10-coil.conflist --protocol $(p) &&) :
 	rm -rf tmp kindnet-conf
+endif
 
-.PHONY: install-coil-egress-v4-originatingonly
-install-coil-egress-v4-originatingonly: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	./kindnet-conf --action get
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/v4-originatingonly | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-v6
-install-coil-egress-v6: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	./kindnet-conf --action get --protocol v6
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/v6 | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v6
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-v6-originatingonly
-install-coil-egress-v6-originatingonly: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	./kindnet-conf --action get --protocol v6
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/v6-originatingonly | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v6
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-v4-nft
-install-coil-egress-v4-nft: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	./kindnet-conf --action get
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/v4-nft | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-v4-nft-originatingonly
-install-coil-egress-v4-nft-originatingonly: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	./kindnet-conf --action get
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/v4-nft-originatingonly | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-v6-nft
-install-coil-egress-v6-nft: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	./kindnet-conf --action get --protocol v6
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/v6-nft | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v6
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-v6-nft-originatingonly
-install-coil-egress-v6-nft-originatingonly: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	./kindnet-conf --action get --protocol v6
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/v6-nft-originatingonly | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v6
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-dualstack
-install-coil-egress-dualstack: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	./kindnet-conf --action get --protocol v4
-	./kindnet-conf --action get --protocol v6
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/dualstack | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v4
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v6
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-dualstack-originatingonly
-install-coil-egress-dualstack-originatingonly: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	./kindnet-conf --action get --protocol v4
-	./kindnet-conf --action get --protocol v6
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/dualstack-originatingonly | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v4
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v6
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-dualstack-nft
-install-coil-egress-dualstack-nft: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	./kindnet-conf --action get --protocol v4
-	./kindnet-conf --action get --protocol v6
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/dualstack-nft | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v4
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v6
-	rm -rf tmp kindnet-conf
-
-.PHONY: install-coil-egress-dualstack-nft-originatingonly 
-install-coil-egress-dualstack-nft-originatingonly: setup-nodes
-	rm -rf tmp
-	mkdir tmp 2> /dev/null
-	$(KUBECTL) rollout status daemonset kindnet -n kube-system --timeout 120s
-	CGO_ENABLED=0 go build -o kindnet-conf ./kindnet-configurer
-	./kindnet-conf --action get --protocol v4
-	./kindnet-conf --action get --protocol v6
-	$(KIND) load docker-image --name coil coil:dev
-	$(KUSTOMIZE) build --load-restrictor=LoadRestrictionsNone configs/egress/dualstack-nft-originatingonly  | $(KUBECTL) apply -f -
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) -n kube-system wait --timeout=3m --for=condition=available deployment/coil-egress-controller
-	$(KUBECTL) rollout status daemonset coild -n kube-system --timeout=3m
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v4
-	./kindnet-conf --action set --cni-config 10-coil.conflist --protocol v6
-	rm -rf tmp kindnet-conf
+# CI-only: enable Docker IPv6 mode when TEST_IPV6=true. Requires sudo.
+.PHONY: ci-enable-docker-ipv6
+ci-enable-docker-ipv6:
+ifeq ($(TEST_IPV6),true)
+	sudo mkdir -p /etc/docker
+	sudo cp daemon.json /etc/docker/daemon.json
+	sudo systemctl restart docker.service
+	sleep 10
+endif
 
 .PHONY: setup-nodes
 setup-nodes:
@@ -258,11 +121,14 @@ setup-nodes:
 	$(KUBECTL) label nodes coil-worker test=coil
 	$(KUBECTL) label nodes coil-worker2 test=coil
 
-TEST_IPAM ?= true
-TEST_EGRESS ?= true
+TEST_IPAM ?= $(WITH_IPAM)
+TEST_ORIGINATINGONLY ?= $(ORIGINATINGONLY)
 .PHONY: test
 test: setup-echotest setup-echotest-image
-	TEST_IPAM=$(TEST_IPAM) TEST_EGRESS=$(TEST_EGRESS) go test -count 1 -v . -args -ginkgo.progress -ginkgo.v
+	TEST_IPAM=$(TEST_IPAM) TEST_EGRESS=$(TEST_EGRESS) \
+	  TEST_IPV4=$(TEST_IPV4) TEST_IPV6=$(TEST_IPV6) \
+	  TEST_ORIGINATINGONLY=$(TEST_ORIGINATINGONLY) \
+	  go test -count 1 -v . -args -ginkgo.progress -ginkgo.v
 
 .PHONY: build-echotest
 build-echotest:


### PR DESCRIPTION
## Overview

- Reduces the e2e matrix from 72 to 23
- Unifies the e2e Makefile
  - `install-coil-egress-*` targets are collapsed into a single env-var-driven `install-coil` target.

## CI matrix policy
- Latest K8s (1.35.1).
  - Exercise all meaningful feature combinations
    - IPAM + EgressNAT vs standalone egress
    - iptables vs nftables
    - ipv4 / ipv6 / dualstack (+ ipv6-primary)
    - originating-only (this is an EgressNAT option).

- Previous K8s (1.34.3, 1.33.7).
  - Run only a small representative subset
    - basic IPAM, dualstack IPAM, egress v4 iptables, egress v4 nftables
  - Checks if coil still works with previous K8s API.

- `originatingonly` is orthogonal to IP family / backend, so it is exercised once per mode on latest rather than
  crossed with every combination.

- IPAM mode is always tested with the iptables backend only.
  - Because IPAM function and EgressNAT function are orthogonal.

## Test Cases

### Latest — K8s 1.35.1 (15)

| Case | Mode          | IP family          | Backend  | OriginatingOnly | Label                                |
| ---- | ------------- | ------------------ | -------- | --------------- | ------------------------------------ |
| A1   | IPAM + Egress | v4                 | iptables | –               | `ipam v4`                            |
| A2   | IPAM + Egress | v6                 | iptables | –               | `ipam v6`                            |
| A3   | IPAM + Egress | dualstack          | iptables | –               | `ipam dual`                          |
| A4   | IPAM + Egress | dualstack (v6-pri) | iptables | –               | `ipam dual-v6p`                      |
| A5   | IPAM + Egress | v4                 | iptables | ✓               | `ipam v4 orig-only`                  |
| B1   | Egress only   | v4                 | iptables | –               | `egress v4 iptables`                 |
| B2   | Egress only   | v6                 | iptables | –               | `egress v6 iptables`                 |
| B3   | Egress only   | dualstack          | iptables | –               | `egress dual iptables`               |
| B4   | Egress only   | dualstack (v6-pri) | iptables | –               | `egress dual-v6p iptables`           |
| B5   | Egress only   | dualstack (v6-pri) | iptables | ✓               | `egress dual-v6p iptables orig-only` |
| C1   | Egress only   | v4                 | nftables | –               | `egress v4 nftables`                 |
| C2   | Egress only   | v6                 | nftables | –               | `egress v6 nftables`                 |
| C3   | Egress only   | dualstack          | nftables | –               | `egress dual nftables`               |
| C4   | Egress only   | dualstack (v6-pri) | nftables | –               | `egress dual-v6p nftables`           |
| C5   | Egress only   | v4                 | nftables | ✓               | `egress v4 nftables orig-only`       |

### Previous — K8s 1.34.3 (4)

| Case | Mode          | IP family | Backend  | OriginatingOnly | Label                |
| ---- | ------------- | --------- | -------- | --------------- | -------------------- |
| P1-1 | IPAM + Egress | v4        | iptables | –               | `ipam v4`            |
| P1-2 | IPAM + Egress | dualstack | iptables | –               | `ipam dual`          |
| P1-3 | Egress only   | v4        | iptables | –               | `egress v4 iptables` |
| P1-4 | Egress only   | v4        | nftables | –               | `egress v4 nftables` |


### Previous — K8s 1.33.7 (4)

| Case | Mode          | IP family | Backend  | OriginatingOnly | Label                |
| ---- | ------------- | --------- | -------- | --------------- | -------------------- |
| P2-1 | IPAM + Egress | v4        | iptables | –               | `ipam v4`            |
| P2-2 | IPAM + Egress | dualstack | iptables | –               | `ipam dual`          |
| P2-3 | Egress only   | v4        | iptables | –               | `egress v4 iptables` |
| P2-4 | Egress only   | v4        | nftables | –               | `egress v4 nftables` |

