### PR TITLE
fix cert-rotator busy loop

### DIFF
--- a/v2/cmd/coil-egress-controller/sub/run.go
+++ b/v2/cmd/coil-egress-controller/sub/run.go
@@ -1,7 +1,6 @@
 package sub
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
@@ -53,6 +52,10 @@ func subMain() error {
 		return fmt.Errorf("invalid webhook address: %w", err)
 	}
 
+	// Load the webhook certificates lazily on TLS handshakes so that the
+	// webhook server can start before the cert rotator generates them.
+	reloader := cert.NewReloader(config.certDir, ctrl.Log.WithName("cert-reloader"))
+
 	timeout := gracefulTimeout
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
@@ -67,7 +70,7 @@ func subMain() error {
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Host:    host,
 			Port:    port,
-			CertDir: config.certDir,
+			TLSOpts: reloader.TLSOpts(),
 		}),
 	})
 	if err != nil {
@@ -81,39 +84,27 @@ func subMain() error {
 		return err
 	}
 
-	certCompleted := make(chan struct{})
-
 	if config.enableCertRotation {
-		if certCompleted, err = cert.SetupRotator(mgr, "egress", config.enableRestartOnCertRefresh, certCompleted); err != nil {
+		if err := cert.SetupRotator(mgr, "egress", config.enableRestartOnCertRefresh, config.certDir); err != nil {
 			return fmt.Errorf("failed to setup Rotator: %w", err)
 		}
-	} else {
-		close(certCompleted)
 	}
 
-	setupErr := make(chan error)
+	// StartedChecker dials the webhook server with TLS, so this keeps the
+	// pod not ready until the certificates become available.
+	if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
+		return err
+	}
 
-	go func() {
-		setupErr <- setupManager(mgr, certCompleted)
-		close(setupErr)
-	}()
+	if err := setupManager(mgr); err != nil {
+		return err
+	}
 
-	mgrCtx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
-	defer cancel()
-
-	mgrErr := make(chan error)
-	go func() {
-		setupLog.Info(fmt.Sprintf("starting manager (version: %s)", v2.Version()))
-		if err := mgr.Start(mgrCtx); err != nil {
-			mgrErr <- err
-		}
-		close(mgrErr)
-	}()
-
-	return cert.WaitForExit(setupErr, mgrErr, cancel)
+	setupLog.Info(fmt.Sprintf("starting manager (version: %s)", v2.Version()))
+	return mgr.Start(ctrl.SetupSignalHandler())
 }
 
-func setupManager(mgr ctrl.Manager, certCompleted chan struct{}) error {
+func setupManager(mgr ctrl.Manager) error {
 	// register controllers
 
 	podNS := os.Getenv(constants.EnvPodNamespace)
@@ -139,9 +130,6 @@ func setupManager(mgr ctrl.Manager, certCompleted chan struct{}) error {
 	if err := controllers.SetupCRBReconciler(mgr); err != nil {
 		return err
 	}
-
-	// wait for certificates to be configured
-	<-certCompleted
 
 	// register webhooks
 	if err := (&coilv2.Egress{}).SetupWebhookWithManager(mgr); err != nil {

--- a/v2/cmd/coil-ipam-controller/sub/run.go
+++ b/v2/cmd/coil-ipam-controller/sub/run.go
@@ -53,6 +53,10 @@ func subMain() error {
 		return fmt.Errorf("invalid webhook address: %w", err)
 	}
 
+	// Load the webhook certificates lazily on TLS handshakes so that the
+	// webhook server can start before the cert rotator generates them.
+	reloader := cert.NewReloader(config.certDir, ctrl.Log.WithName("cert-reloader"))
+
 	timeout := gracefulTimeout
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
@@ -67,7 +71,7 @@ func subMain() error {
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Host:    host,
 			Port:    port,
-			CertDir: config.certDir,
+			TLSOpts: reloader.TLSOpts(),
 		}),
 	})
 	if err != nil {
@@ -81,40 +85,29 @@ func subMain() error {
 		return err
 	}
 
-	certCompleted := make(chan struct{})
-
 	if config.enableCertRotation {
-		if certCompleted, err = cert.SetupRotator(mgr, "ipam", config.enableRestartOnCertRefresh, certCompleted); err != nil {
+		if err := cert.SetupRotator(mgr, "ipam", config.enableRestartOnCertRefresh, config.certDir); err != nil {
 			return fmt.Errorf("failed to setup Rotator: %w", err)
 		}
-	} else {
-		close(certCompleted)
+	}
+
+	// StartedChecker dials the webhook server with TLS, so this keeps the
+	// pod not ready until the certificates become available.
+	if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
+		return err
 	}
 
 	ctx := ctrl.SetupSignalHandler()
 
-	setupErr := make(chan error)
+	if err := setupManager(ctx, mgr); err != nil {
+		return err
+	}
 
-	go func() {
-		setupErr <- setupManager(ctx, mgr, certCompleted)
-		close(setupErr)
-	}()
-
-	mgrCtx, cancel := context.WithCancel(ctx)
-
-	mgrErr := make(chan error)
-	go func() {
-		setupLog.Info(fmt.Sprintf("starting manager (version: %s)", v2.Version()))
-		if err := mgr.Start(mgrCtx); err != nil {
-			mgrErr <- err
-		}
-		close(mgrErr)
-	}()
-
-	return cert.WaitForExit(setupErr, mgrErr, cancel)
+	setupLog.Info(fmt.Sprintf("starting manager (version: %s)", v2.Version()))
+	return mgr.Start(ctx)
 }
 
-func setupManager(ctx context.Context, mgr ctrl.Manager, certCompleted chan struct{}) error {
+func setupManager(ctx context.Context, mgr ctrl.Manager) error {
 	// register controllers
 
 	pm := ipam.NewPoolManager(mgr.GetClient(), mgr.GetAPIReader(), ctrl.Log.WithName("pool-manager"), scheme)
@@ -139,9 +132,6 @@ func setupManager(ctx context.Context, mgr ctrl.Manager, certCompleted chan stru
 	if err := brctrl.SetupWithManager(mgr); err != nil {
 		return err
 	}
-
-	// wait for certificates to be configured
-	<-certCompleted
 
 	// register webhooks
 

--- a/v2/pkg/cert/cert.go
+++ b/v2/pkg/cert/cert.go
@@ -1,9 +1,14 @@
 package cert
 
 import (
-	"context"
+	"crypto/tls"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/open-policy-agent/cert-controller/pkg/rotator"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -12,7 +17,7 @@ import (
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;update
 
-func SetupRotator(mgr ctrl.Manager, objectType string, enableRestartOnCertRefresh bool, setupFinished chan struct{}) (chan struct{}, error) {
+func SetupRotator(mgr ctrl.Manager, objectType string, enableRestartOnCertRefresh bool, certDir string) error {
 	webhooks := []rotator.WebhookInfo{
 		{
 			Name: fmt.Sprintf("coilv2-validating-%s-webhook-configuration", objectType),
@@ -33,36 +38,75 @@ func SetupRotator(mgr ctrl.Manager, objectType string, enableRestartOnCertRefres
 			Namespace: podNamespace,
 			Name:      secretName,
 		},
-		CertDir:                "/certs",
+		CertDir:                certDir,
 		CAName:                 fmt.Sprintf("coil-%s-ca", objectType),
 		CAOrganization:         "coil",
 		DNSName:                fmt.Sprintf("%s.%s.svc", serviceName, podNamespace),
 		ExtraDNSNames:          []string{fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, podNamespace)},
-		IsReady:                setupFinished,
+		IsReady:                make(chan struct{}),
 		RequireLeaderElection:  false,
 		Webhooks:               webhooks,
 		RestartOnSecretRefresh: enableRestartOnCertRefresh,
 	}); err != nil {
-		return nil, fmt.Errorf("unable to set up cert rotation: %w", err)
+		return fmt.Errorf("unable to set up cert rotation: %w", err)
 	}
 
-	return setupFinished, nil
+	return nil
 }
 
-func WaitForExit(setupErr, mgrErr chan error, cancel context.CancelFunc) error {
-	logger := ctrl.Log.WithName("coil")
-	for {
-		select {
-		case err := <-setupErr:
-			if err != nil {
-				logger.Error(err, "unable to setup reconcilers")
-				cancel() // if error occurred during setup cancel manager's context
-			}
-		case err := <-mgrErr:
-			if err != nil {
-				return fmt.Errorf("manager error: %w", err)
-			}
-			return nil
+// Reloader loads the webhook server certificate lazily on TLS handshakes
+// and reloads it when the certificate file is updated.  Unlike
+// controller-runtime's certwatcher, it tolerates certificate files that do
+// not exist yet at server startup; TLS handshakes just fail until the files
+// appear (e.g. until kubelet syncs the Secret updated by the cert rotator).
+type Reloader struct {
+	certPath string
+	keyPath  string
+	log      logr.Logger
+
+	mu      sync.Mutex
+	cert    *tls.Certificate
+	modTime time.Time
+}
+
+// NewReloader creates a Reloader that loads tls.crt and tls.key from dir.
+func NewReloader(dir string, log logr.Logger) *Reloader {
+	return &Reloader{
+		certPath: filepath.Join(dir, "tls.crt"),
+		keyPath:  filepath.Join(dir, "tls.key"),
+		log:      log,
+	}
+}
+
+// GetCertificate is intended for tls.Config.GetCertificate.
+// Once a certificate has been loaded, it keeps serving the cached one
+// even if the files disappear or become corrupt afterwards.
+func (r *Reloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	st, err := os.Stat(r.certPath)
+	if err == nil && (r.cert == nil || !st.ModTime().Equal(r.modTime)) {
+		if cert, lerr := tls.LoadX509KeyPair(r.certPath, r.keyPath); lerr == nil {
+			r.cert = &cert
+			r.modTime = st.ModTime()
+		} else {
+			err = lerr
 		}
+	}
+	if r.cert == nil {
+		return nil, fmt.Errorf("webhook certificate is not ready: %w", err)
+	}
+	if err != nil {
+		r.log.Error(err, "failed to reload the webhook certificate; keep serving the cached one")
+	}
+	return r.cert, nil
+}
+
+// TLSOpts is intended for webhook.Options.TLSOpts.  It makes the webhook
+// server obtain its certificate from the Reloader.
+func (r *Reloader) TLSOpts() []func(*tls.Config) {
+	return []func(*tls.Config){
+		func(c *tls.Config) { c.GetCertificate = r.GetCertificate },
 	}
 }

--- a/v2/pkg/cert/cert_test.go
+++ b/v2/pkg/cert/cert_test.go
@@ -1,0 +1,245 @@
+package cert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func writeCertFiles(t *testing.T, dir string, serial int64, mtime time.Time) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: "coil-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	if err := os.WriteFile(filepath.Join(dir, "tls.crt"), certPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.key"), keyPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filepath.Join(dir, "tls.crt"), mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func serialOf(t *testing.T, cert *tls.Certificate) int64 {
+	t.Helper()
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return leaf.SerialNumber.Int64()
+}
+
+func TestReloaderLoadsAfterFilesAppear(t *testing.T) {
+	dir := t.TempDir()
+	r := NewReloader(dir, logr.Discard())
+
+	if _, err := r.GetCertificate(nil); err == nil {
+		t.Fatal("expected an error before certificate files exist")
+	}
+
+	writeCertFiles(t, dir, 1, time.Now())
+	cert, err := r.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if serialOf(t, cert) != 1 {
+		t.Errorf("unexpected serial: %d", serialOf(t, cert))
+	}
+}
+
+func TestReloaderReloadsUpdatedFile(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Now()
+	writeCertFiles(t, dir, 1, base)
+	r := NewReloader(dir, logr.Discard())
+
+	if _, err := r.GetCertificate(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	writeCertFiles(t, dir, 2, base.Add(time.Second))
+	cert, err := r.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if serialOf(t, cert) != 2 {
+		t.Errorf("expected reloaded certificate with serial 2, got %d", serialOf(t, cert))
+	}
+}
+
+// kubelet updates a Secret volume by atomically swapping the "..data"
+// symlink that tls.crt and tls.key point into.
+func TestReloaderSymlinkSwap(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Now()
+
+	makeData := func(name string, serial int64, mtime time.Time) {
+		dataDir := filepath.Join(dir, name)
+		if err := os.Mkdir(dataDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		writeCertFiles(t, dataDir, serial, mtime)
+	}
+	swapData := func(name string) {
+		tmp := filepath.Join(dir, "..data_tmp")
+		if err := os.Symlink(name, tmp); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(tmp, filepath.Join(dir, "..data")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	makeData("..data_1", 1, base)
+	swapData("..data_1")
+	for _, f := range []string{"tls.crt", "tls.key"} {
+		if err := os.Symlink(filepath.Join("..data", f), filepath.Join(dir, f)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	r := NewReloader(dir, logr.Discard())
+	cert, err := r.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if serialOf(t, cert) != 1 {
+		t.Errorf("unexpected serial: %d", serialOf(t, cert))
+	}
+
+	makeData("..data_2", 2, base.Add(time.Second))
+	swapData("..data_2")
+
+	cert, err = r.GetCertificate(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if serialOf(t, cert) != 2 {
+		t.Errorf("expected certificate from the swapped directory, got serial %d", serialOf(t, cert))
+	}
+}
+
+func TestReloaderKeepsCacheOnBrokenUpdate(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Now()
+	writeCertFiles(t, dir, 1, base)
+	r := NewReloader(dir, logr.Discard())
+
+	if _, err := r.GetCertificate(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	certPath := filepath.Join(dir, "tls.crt")
+	if err := os.WriteFile(certPath, []byte("broken"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	mtime := base.Add(time.Second)
+	if err := os.Chtimes(certPath, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	cert, err := r.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("broken update should not invalidate the cached certificate: %v", err)
+	}
+	if serialOf(t, cert) != 1 {
+		t.Errorf("expected the cached certificate, got serial %d", serialOf(t, cert))
+	}
+
+	if err := os.Remove(certPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.GetCertificate(nil); err != nil {
+		t.Fatalf("file removal should not invalidate the cached certificate: %v", err)
+	}
+}
+
+func TestReloaderTLSHandshake(t *testing.T) {
+	dir := t.TempDir()
+	r := NewReloader(dir, logr.Discard())
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{GetCertificate: r.GetCertificate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				_ = conn.(*tls.Conn).Handshake()
+				conn.Close()
+			}(conn)
+		}
+	}()
+
+	dial := func() (int64, error) {
+		conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return 0, err
+		}
+		defer conn.Close()
+		return conn.ConnectionState().PeerCertificates[0].SerialNumber.Int64(), nil
+	}
+
+	base := time.Now()
+	writeCertFiles(t, dir, 1, base)
+	if _, err := dial(); err != nil {
+		t.Fatal(err)
+	}
+
+	writeCertFiles(t, dir, 2, base.Add(time.Second))
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			serial, err := dial()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if serial != 2 {
+				t.Errorf("expected rotated certificate, got serial %d", serial)
+			}
+		})
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #374 .

`coil-ipam-controller` and `coil-egress-controller` spin at 100% CPU after startup. `cert.WaitForExit` caused this busy loop.

This PR removes the channel-based startup process.
`cert.Reloader` loads the webhook certificates lazily on TLS handshakes, so the webhook server can start before the cert rotator generates them.

I've verified controller CPU usages stay at ~0.5% on my local environment.

Signed-off-by: terashima <tomoya-terashima@cybozu.co.jp>
