### PR TITLE
[Fix #382] Table 116 could get out of sync

### DIFF
--- a/v2/cmd/coild/sub/run.go
+++ b/v2/cmd/coild/sub/run.go
@@ -114,6 +114,9 @@ func subMain() error {
 	if err := podNet.Init(); err != nil {
 		return err
 	}
+	if err := nodenet.ReconcilePodRoutes(podNet); err != nil {
+		return err
+	}
 
 	if cfg.EnableIPAM {
 		podConfigs, err := podNet.List()

--- a/v2/pkg/nodenet/pod.go
+++ b/v2/pkg/nodenet/pod.go
@@ -253,8 +253,7 @@ func ReconcilePodRoutes(pn PodNetwork) error {
 
 func addNetlinkRoute(route *netlink.Route) (bool, error) {
 	if err := netlink.RouteAdd(route); err != nil {
-		var routeErr *netlink.OpError
-		if errors.As(err, &routeErr) && routeErr.Err == syscall.EEXIST {
+		if errors.Is(err, syscall.EEXIST) {
 			return false, nil
 		}
 		return false, err

--- a/v2/pkg/nodenet/pod.go
+++ b/v2/pkg/nodenet/pod.go
@@ -228,6 +228,71 @@ func (pn *podNetwork) Init() error {
 	return nil
 }
 
+func ReconcilePodRoutes(pn PodNetwork) error {
+	impl, ok := pn.(*podNetwork)
+	if !ok {
+		return fmt.Errorf("unsupported pod network implementation %T", pn)
+	}
+
+	confs, err := pn.List()
+	if err != nil {
+		return fmt.Errorf("failed to list pod configs for startup route reconciliation: %w", err)
+	}
+
+	for _, conf := range confs {
+		if conf == nil {
+			continue
+		}
+		if err := ensurePodRoute(impl, conf); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addNetlinkRoute(route *netlink.Route) (bool, error) {
+	if err := netlink.RouteAdd(route); err != nil {
+		var routeErr *netlink.OpError
+		if errors.As(err, &routeErr) && routeErr.Err == syscall.EEXIST {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func ensurePodRoute(pn *podNetwork, conf *PodNetConf) error {
+	link, err := netlink.LinkByName(conf.HostVethName)
+	if err != nil {
+		return fmt.Errorf("netlink: failed to look up host-side veth %s for startup route reconciliation: %w", conf.HostVethName, err)
+	}
+
+	for _, ip := range []net.IP{conf.IPv4, conf.IPv6} {
+		if ip == nil {
+			continue
+		}
+
+		added, err := addNetlinkRoute(&netlink.Route{
+			Dst:       netlink.NewIPNet(ip),
+			LinkIndex: link.Attrs().Index,
+			Scope:     netlink.SCOPE_LINK,
+			Protocol:  pn.protocolId,
+			Table:     pn.podTableId,
+		})
+		if err != nil {
+			return fmt.Errorf("netlink: failed to ensure startup route for %s to %s in table %d: %w", conf.HostVethName, ip.String(), pn.podTableId, err)
+		}
+		if added {
+			pn.log.V(1).Info("startup pod route created", "name", conf.HostVethName, "ip", ip.String(), "table", pn.podTableId)
+			continue
+		}
+		pn.log.V(1).Info("startup pod route already exists; skip", "name", conf.HostVethName, "ip", ip.String(), "table", pn.podTableId)
+	}
+
+	return nil
+}
+
 func (pn *podNetwork) initRule(family int) error {
 	rules, err := netlink.RuleList(family)
 	if err != nil {

--- a/v2/runners/coild_server.go
+++ b/v2/runners/coild_server.go
@@ -304,6 +304,9 @@ func (s *coildServer) Add(ctx context.Context, args *cnirpc.CNIArgs) (*cnirpc.Ad
 
 		hook, err := s.getHook(ctx, pod)
 		if err != nil {
+			if s.cfg.EnableIPAM {
+				s.cleanupIPAM(ctx, logger, args.ContainerId, args.Ifname)
+			}
 			logger.Sugar().Errorw("failed to setup NAT hook", "error", err)
 			return nil, newInternalError(err, "failed to setup NAT hook")
 		}
@@ -311,6 +314,9 @@ func (s *coildServer) Add(ctx context.Context, args *cnirpc.CNIArgs) (*cnirpc.Ad
 		if hook != nil {
 			logger.Sugar().Info("enabling NAT")
 			if err := s.podNet.SetupEgress(args.Netns, config, hook); err != nil {
+				if s.cfg.EnableIPAM {
+					s.cleanupIPAM(ctx, logger, args.ContainerId, args.Ifname)
+				}
 				return nil, newInternalError(err, "failed to setup pod network egress")
 			}
 		}
@@ -319,17 +325,21 @@ func (s *coildServer) Add(ctx context.Context, args *cnirpc.CNIArgs) (*cnirpc.Ad
 	data, err := json.Marshal(result)
 	if err != nil {
 		if s.cfg.EnableIPAM {
-			if err := s.podNet.Destroy(args.ContainerId, args.Ifname); err != nil {
-				logger.Sugar().Warnw("failed to destroy pod network", "error", err)
-			}
-			if err := s.nodeIPAM.Free(ctx, args.ContainerId, args.Ifname); err != nil {
-				logger.Sugar().Warnw("failed to deallocate address", "error", err)
-			}
+			s.cleanupIPAM(ctx, logger, args.ContainerId, args.Ifname)
 		}
 		logger.Sugar().Errorw("failed to marshal the result", "error", err)
 		return nil, newInternalError(err, "failed to marshal the result")
 	}
 	return &cnirpc.AddResponse{Result: data}, nil
+}
+
+func (s *coildServer) cleanupIPAM(ctx context.Context, logger *zap.Logger, containerID, iface string) {
+	if err := s.podNet.Destroy(containerID, iface); err != nil {
+		logger.Sugar().Warnw("failed to destroy pod network", "error", err)
+	}
+	if err := s.nodeIPAM.Free(ctx, containerID, iface); err != nil {
+		logger.Sugar().Warnw("failed to deallocate address", "error", err)
+	}
 }
 
 func (s *coildServer) setCoilInterfaceAlias(interfaces map[string]bool, conf *nodenet.PodNetConf) error {


### PR DESCRIPTION
While I investigated issue #382, I also found a related Bug for EgressNAT.

* The fix approach for #382 just reconciles the table at the start of coild
   This should ensure if coild crashes in the mid of a CNI ADD call the routes are always in sync on a fresh start
* Additionally it cleans up some orphan IPAM things, as they were not cleaned up before due to an early return

